### PR TITLE
Add Permission Delegation to applicable transaction workloads

### DIFF
--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -23,6 +23,6 @@ from workload.sequence import SequenceTracker
 from workload.ws_listener import start_ws_listener
 from workload.setup import run_setup
 from workload.params import should_send_faulty, fake_account, fake_id
-from workload.models import UserAccount, Credential, Vault, PermissionedDomain, MPTokenIssuance, LoanBroker, Loan
+from workload.models import UserAccount, Credential, Vault, PermissionedDomain, MPTokenIssuance, LoanBroker, Loan, Delegate
 print('All imports OK')
 "

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -37,6 +37,7 @@ class Workload:
         self.vaults = []
         self.domains = []
         self.mpt_issuances = []
+        self.delegates = []
         self.loan_brokers = []
         self.loans = []
         self.deleted_vault_ids: list[str] = []
@@ -78,6 +79,10 @@ class Workload:
         self.seq = SequenceTracker(self.client)
 
         self.wait_for_network(self.xrpld)
+
+        # Wire delegation state so submit_tx can transparently delegate.
+        from workload.submit import configure as configure_submit
+        configure_submit(self.delegates, self.accounts)
 
         logger.info("Antithesis SDK handler: %s", type(_HANDLER).__name__)
         reachable("workload::started", {})

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -66,6 +66,14 @@ class UserAccount(Account):
 
 
 @dataclass
+class Delegate:
+    """A delegation relationship: source granted delegate_address permission."""
+    source: str
+    delegate_address: str
+    permissions: list[str]  # TransactionType values e.g. ["Payment", "TrustSet"]
+
+
+@dataclass
 class Amm:
     account: str
     assets: list[IssuedCurrency]

--- a/workload/src/workload/submit.py
+++ b/workload/src/workload/submit.py
@@ -15,6 +15,21 @@ from workload.assertions import tx_submitted
 
 log = logging.getLogger(__name__)
 
+# ── Delegation state (set once via configure()) ──────────────────────
+_delegates: list = []
+_accounts: dict = {}
+
+
+def configure(delegates: list, accounts: dict) -> None:
+    """Store references to workload delegation state.
+
+    Called once during ``Workload.__init__`` so that ``submit_tx`` can
+    transparently apply delegation without any handler changes.
+    """
+    global _delegates, _accounts
+    _delegates = delegates
+    _accounts = accounts
+
 
 async def submit_tx(
     name: str,
@@ -31,12 +46,27 @@ async def submit_tx(
     If ``seq`` is provided, it is stamped onto the transaction before
     autofill so that xrpl-py skips the RPC sequence fetch.
 
+    When delegation state is configured (via ``configure``), there is a
+    10% chance that a matching delegate will sign on behalf of the
+    source account for delegable transaction types.
+
     Raises XRPLRequestFailureException on RPC-level failures (connection
     refused, malformed request, etc.) — let it propagate to the endpoint
     handler's XRPLException catch.
     """
     if seq is not None:
         txn = txn.__replace__(sequence=seq)
+
+    # Possibly delegate: lazy import to avoid circular dependency
+    if _delegates:
+        from workload.transactions.delegation import maybe_delegate
+        delegate_addr, delegate_wallet = maybe_delegate(
+            name, txn.account, _delegates, _accounts,
+        )
+        if delegate_addr is not None:
+            txn = txn.__replace__(delegate=delegate_addr)
+            wallet = delegate_wallet
+
     signed = await autofill_and_sign(txn, client, wallet)
     response = await submit(signed, client)
     result = response.result

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -333,10 +333,14 @@ def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
     source = tx.get("Account", "")
     delegate_addr = tx.get("Authorize", "")
     perms_raw = tx.get("Permissions", [])
+    # Only keep permission values that are transaction type names;
+    # GranularPermission values (e.g. "TrustlineAuthorize") will never
+    # match a tx_type in maybe_delegate, so filter them out.
+    tx_type_names = set(TX_TYPES)
     permissions = []
     for p in perms_raw:
         pv = p.get("Permission", {}).get("PermissionValue", "")
-        if pv:
+        if pv and pv in tx_type_names:
             permissions.append(pv)
     if not permissions:
         return

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -27,6 +27,7 @@ from xrpl.models.currencies import MPTCurrency
 from workload.models import (
     NFT,
     Credential,
+    Delegate,
     Loan,
     LoanBroker,
     MPTokenIssuance,
@@ -328,6 +329,25 @@ def _on_loan_pay(w: Workload, tx: dict, meta: dict) -> None:
         loan.principal = max(0, loan.principal - _extract_amount(tx))
 
 
+def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
+    source = tx.get("Account", "")
+    delegate_addr = tx.get("Authorize", "")
+    perms_raw = tx.get("Permissions", [])
+    permissions = []
+    for p in perms_raw:
+        pv = p.get("Permission", {}).get("PermissionValue", "")
+        if pv:
+            permissions.append(pv)
+    if not permissions:
+        return
+    # Replace existing delegation from same source to same delegate
+    w.delegates[:] = [
+        d for d in w.delegates
+        if not (d.source == source and d.delegate_address == delegate_addr)
+    ]
+    w.delegates.append(Delegate(source=source, delegate_address=delegate_addr, permissions=permissions))
+
+
 # ── Registry ─────────────────────────────────────────────────────────
 # (name, path, handler, args_fn, state_updater_or_None)
 
@@ -526,7 +546,7 @@ REGISTRY = [
         "/delegate/set/random",
         delegate_set,
         lambda w: (w.accounts, w.client),
-        None,
+        _on_delegate_set,
     ),
     (
         "LoanBrokerSet",

--- a/workload/src/workload/transactions/delegation.py
+++ b/workload/src/workload/transactions/delegation.py
@@ -95,3 +95,45 @@ async def _delegate_set_faulty(
             permissions=permissions,
         )
         await submit_tx("DelegateSet", txn, client, impostor.wallet)
+
+
+
+# ── Delegation helper for submit_tx ──────────────────────────────────
+
+# Names of non-delegable transaction types for fast lookup.
+_NON_DELEGABLE_NAMES: set[str] = {t.value for t in NON_DELEGABLE_TRANSACTIONS}
+
+
+def maybe_delegate(
+    tx_type: str,
+    src_address: str,
+    delegates: list,
+    accounts: dict[str, UserAccount],
+) -> tuple[str | None, object | None]:
+    """Possibly pick a delegate to submit *tx_type* on behalf of *src_address*.
+
+    Returns ``(delegate_address, delegate_wallet)`` when delegation should
+    happen, or ``(None, None)`` otherwise.
+
+    Called from ``submit_tx`` — no handler changes required.
+    """
+    from workload.randoms import random as _random
+
+    if tx_type in _NON_DELEGABLE_NAMES:
+        return None, None
+    if not delegates:
+        return None, None
+    if _random() >= 0.10:
+        return None, None
+
+    candidates = [
+        d for d in delegates
+        if d.source == src_address
+        and tx_type in d.permissions
+        and d.delegate_address in accounts
+    ]
+    if not candidates:
+        return None, None
+    d = choice(candidates)
+    acct = accounts[d.delegate_address]
+    return acct.address, acct.wallet


### PR DESCRIPTION
Adds support for XRPL permission delegation ([DelegateSet](https://xrpl.org/docs/references/protocol/transactions/types/delegateset)), allowing transactions to be submitted by delegates on behalf of source accounts.

**Changes:**
models.py — New Delegate dataclass (source → delegate address + permitted tx types)
delegation.py — maybe_delegate() helper picks a matching delegate for delegable tx types
submit.py — submit_tx transparently applies delegation; configure() wires state from Workload
Delegation probability set to 10% and it is handled entirely within submit_tx.