### PR TITLE
AMM and Offer workloads

### DIFF
--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -13,6 +13,7 @@ from workload.transactions.delegation import delegate_set
 from workload.transactions.amm import amm_create, amm_deposit, amm_withdraw, amm_vote, amm_bid, amm_delete
 from workload.transactions.mpt import mpt_create, mpt_authorize, mpt_issuance_set, mpt_destroy
 from workload.transactions.nft import nftoken_mint, nftoken_modify
+from workload.transactions.offers import offer_create, offer_cancel
 from workload.transactions.lending import (
     loan_broker_set, loan_broker_delete,
     loan_broker_cover_deposit, loan_broker_cover_withdraw,

--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -10,6 +10,7 @@ from workload.transactions.credentials import credential_create, credential_acce
 from workload.transactions.vaults import vault_create, vault_deposit, vault_withdraw, vault_set, vault_delete, vault_clawback
 from workload.transactions.domains import permissioned_domain_set, permissioned_domain_delete
 from workload.transactions.delegation import delegate_set
+from workload.transactions.amm import amm_create, amm_deposit, amm_withdraw, amm_vote, amm_bid, amm_delete
 from workload.transactions.mpt import mpt_create, mpt_authorize, mpt_issuance_set, mpt_destroy
 from workload.transactions.nft import nftoken_mint, nftoken_modify
 from workload.transactions.lending import (

--- a/test_composer/all_transactions/parallel_driver_amm_bid_random.sh
+++ b/test_composer/all_transactions/parallel_driver_amm_bid_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/amm/bid/random

--- a/test_composer/all_transactions/parallel_driver_amm_create_random.sh
+++ b/test_composer/all_transactions/parallel_driver_amm_create_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/amm/create/random

--- a/test_composer/all_transactions/parallel_driver_amm_delete_random.sh
+++ b/test_composer/all_transactions/parallel_driver_amm_delete_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/amm/delete/random

--- a/test_composer/all_transactions/parallel_driver_amm_deposit_random.sh
+++ b/test_composer/all_transactions/parallel_driver_amm_deposit_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/amm/deposit/random

--- a/test_composer/all_transactions/parallel_driver_amm_vote_random.sh
+++ b/test_composer/all_transactions/parallel_driver_amm_vote_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/amm/vote/random

--- a/test_composer/all_transactions/parallel_driver_amm_withdraw_random.sh
+++ b/test_composer/all_transactions/parallel_driver_amm_withdraw_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/amm/withdraw/random

--- a/test_composer/all_transactions/parallel_driver_offer_cancel_random.sh
+++ b/test_composer/all_transactions/parallel_driver_offer_cancel_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/offer/cancel/random

--- a/test_composer/all_transactions/parallel_driver_offer_create_random.sh
+++ b/test_composer/all_transactions/parallel_driver_offer_create_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/offer/create/random

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -40,6 +40,7 @@ class Workload:
         self.delegates = []
         self.loan_brokers = []
         self.loans = []
+        self.offers: list[dict] = []
         self.deleted_vault_ids: list[str] = []
         self.deleted_broker_ids: list[str] = []
         self.deleted_loan_ids: list[str] = []

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -83,6 +83,7 @@ class Workload:
 
         # Wire delegation state so submit_tx can transparently delegate.
         from workload.submit import configure as configure_submit
+
         configure_submit(self.delegates, self.accounts)
 
         logger.info("Antithesis SDK handler: %s", type(_HANDLER).__name__)

--- a/workload/src/workload/assertions.py
+++ b/workload/src/workload/assertions.py
@@ -85,9 +85,7 @@ def register_assertions() -> None:
     _emit_catalog_entry(
         "workload::always : no_internal_rippled_error", "always", "Always", must_hit=True
     )
-    _emit_catalog_entry(
-        "workload::always : no_temDISABLED", "always", "Always", must_hit=True
-    )
+    _emit_catalog_entry("workload::always : no_temDISABLED", "always", "Always", must_hit=True)
     for setup_key in [
         "gateways",
         "trust_lines",

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -74,7 +74,7 @@ class Delegate:
 
 
 @dataclass
-class Amm:
+class AMM:
     account: str
     assets: list[IssuedCurrency]
     lp_token: list[IssuedCurrency]

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -131,3 +131,10 @@ class Loan:
     principal: int = 0
     is_defaulted: bool = False
     is_impaired: bool = False
+
+
+@dataclass
+class Delegate:
+    source: str
+    delegate_address: str
+    permissions: list[str] = field(default_factory=list)

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -131,10 +131,3 @@ class Loan:
     principal: int = 0
     is_defaulted: bool = False
     is_impaired: bool = False
-
-
-@dataclass
-class Delegate:
-    source: str
-    delegate_address: str
-    permissions: list[str] = field(default_factory=list)

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -68,6 +68,7 @@ class UserAccount(Account):
 @dataclass
 class Delegate:
     """A delegation relationship: source granted delegate_address permission."""
+
     source: str
     delegate_address: str
     permissions: list[str]  # TransactionType values e.g. ["Payment", "TrustSet"]

--- a/workload/src/workload/params.py
+++ b/workload/src/workload/params.py
@@ -165,6 +165,47 @@ def mpt_metadata() -> str:
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
+# ── AMM ─────────────────────────────────────────────────────────────
+def amm_trading_fee() -> int:
+    """Trading fee in 1/100,000th (0-1000 = 0-1%)."""
+    return randint(0, 1000)
+
+
+def amm_deposit_amount() -> str:
+    """AMM deposit amount for IOU tokens."""
+    return str(randint(100, 100_000))
+
+
+def amm_withdraw_amount() -> str:
+    """AMM withdrawal amount for IOU tokens."""
+    return str(randint(100, 50_000))
+
+
+def amm_lp_token_amount() -> str:
+    """LP token amount for deposits/withdrawals/bids."""
+    return str(randint(1, 10_000))
+
+
+def amm_bid_min() -> str:
+    """Minimum bid price for auction slot."""
+    return str(randint(1, 1_000))
+
+
+def amm_bid_max() -> str:
+    """Maximum bid price for auction slot."""
+    return str(randint(1_000, 10_000))
+
+
+def amm_vote_fee() -> int:
+    """Fee value for AMM vote (0-1000)."""
+    return randint(0, 1000)
+
+
+def amm_xrp_amount() -> str:
+    """XRP amount in drops for AMM pools."""
+    return str(randint(10_000_000, 1_000_000_000))
+
+
 # ── Lending Protocol ─────────────────────────────────────────────────
 def loan_broker_management_fee_rate() -> int:
     """1/10th basis point fee (0-10000 = 0-10%)."""

--- a/workload/src/workload/params.py
+++ b/workload/src/workload/params.py
@@ -172,8 +172,8 @@ def amm_trading_fee() -> int:
 
 
 def amm_deposit_amount() -> str:
-    """AMM deposit amount for IOU tokens."""
-    return str(randint(100, 100_000))
+    """AMM deposit amount for IOU tokens (within typical 10k balance)."""
+    return str(randint(100, 5_000))
 
 
 def amm_withdraw_amount() -> str:

--- a/workload/src/workload/setup.py
+++ b/workload/src/workload/setup.py
@@ -1,7 +1,7 @@
 """Deterministic setup for the Antithesis first_* phase.
 
 Creates the minimum ledger state needed for all transaction types to operate,
-including IOU gateways with token distribution and MPT authorization.
+including IOU gateways with token distribution, MPT authorization, and AMM pools.
 
 Account allocation:
   [0..4]   — MPT issuers
@@ -12,6 +12,8 @@ Account allocation:
   [50..52] — Domain creators
   [60..61] — IOU gateways (DefaultRipple + AllowTrustLineClawback set)
   [62..71] — IOU/MPT holders (trust lines + balances for all currencies)
+  [62]     — also creates XRP/USD AMM
+  [63]     — also creates USD/EUR AMM
 """
 
 from __future__ import annotations
@@ -34,6 +36,7 @@ from xrpl.models.currencies import MPTCurrency
 from xrpl.models.transactions import (
     AccountSet,
     AccountSetAsfFlag,
+    AMMCreate,
     CredentialCreate,
     LoanBrokerCoverDeposit,
     LoanBrokerSet,
@@ -69,6 +72,9 @@ _VAULT_ASSETS_MAXIMUM = "1000000000"
 _TICKET_COUNT = 5
 _IOU_DISTRIBUTION_AMOUNT = "10000"
 _MPT_DISTRIBUTION_AMOUNT = "10000"
+_AMM_XRP_AMOUNT = "100000000"  # 100 XRP in drops
+_AMM_IOU_AMOUNT = "5000"  # IOU tokens per side
+_AMM_TRADING_FEE = 500  # 0.5%
 _COVER_DEPOSIT = "10000000"  # 10 XRP
 _LOAN_PRINCIPAL = "1000000"  # 1 XRP
 _LOAN_INTEREST = 1000  # 1% annualized
@@ -539,6 +545,57 @@ async def run_setup(workload: Workload) -> dict[str, int]:
             )
         )
     summary["nft_offers"] = await _submit_batch("nft_offers", nft_offer_txns, client, seq)
+
+    # ── 8c. AMMs: seed pools so Deposit/Withdraw/Vote/Bid/Delete aren't no-ops
+    amm_txns = []
+    if len(accs) > 63:
+        gw0_idx, gw0_currencies = _GATEWAYS[0]  # (60, ["USD", "BTC"])
+        gw1_idx, gw1_currencies = _GATEWAYS[1]  # (61, ["EUR", "GBP"])
+        gw0_addr = accs[gw0_idx].address if gw0_idx < len(accs) else None
+        gw1_addr = accs[gw1_idx].address if gw1_idx < len(accs) else None
+
+        # AMM 1: XRP / USD — created by holder account[62]
+        if gw0_addr:
+            amm_txns.append(
+                (
+                    "AMMCreate",
+                    AMMCreate(
+                        account=accs[62].address,
+                        amount=_AMM_XRP_AMOUNT,
+                        amount2=IssuedCurrencyAmount(
+                            currency=gw0_currencies[0],
+                            issuer=gw0_addr,
+                            value=_AMM_IOU_AMOUNT,
+                        ),
+                        trading_fee=_AMM_TRADING_FEE,
+                    ),
+                    accs[62].wallet,
+                )
+            )
+
+        # AMM 2: USD / EUR — created by holder account[63]
+        if gw0_addr and gw1_addr:
+            amm_txns.append(
+                (
+                    "AMMCreate",
+                    AMMCreate(
+                        account=accs[63].address,
+                        amount=IssuedCurrencyAmount(
+                            currency=gw0_currencies[0],
+                            issuer=gw0_addr,
+                            value=_AMM_IOU_AMOUNT,
+                        ),
+                        amount2=IssuedCurrencyAmount(
+                            currency=gw1_currencies[0],
+                            issuer=gw1_addr,
+                            value=_AMM_IOU_AMOUNT,
+                        ),
+                        trading_fee=_AMM_TRADING_FEE,
+                    ),
+                    accs[63].wallet,
+                )
+            )
+    summary["amms"] = await _submit_batch("amms", amm_txns, client, seq)
 
     # ── 9. Credentials ───────────────────────────────────────────────
     if len(accs) > 35:

--- a/workload/src/workload/submit.py
+++ b/workload/src/workload/submit.py
@@ -60,8 +60,12 @@ async def submit_tx(
     # Possibly delegate: lazy import to avoid circular dependency
     if _delegates:
         from workload.transactions.delegation import maybe_delegate
+
         delegate_addr, delegate_wallet = maybe_delegate(
-            name, txn.account, _delegates, _accounts,
+            name,
+            txn.account,
+            _delegates,
+            _accounts,
         )
         if delegate_addr is not None:
             txn = txn.__replace__(delegate=delegate_addr)

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -636,7 +636,7 @@ REGISTRY = [
         "AMMVote",
         "/amm/vote/random",
         amm_vote,
-        lambda w: (w.accounts, w.amms, w.client),
+        lambda w: (w.accounts, w.amms, w.trust_lines, w.client),
         None,
     ),
     (

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -65,6 +65,7 @@ from workload.transactions.lending import (
     loan_set,
 )
 from workload.transactions.mpt import mpt_authorize, mpt_create, mpt_destroy, mpt_issuance_set
+from workload.transactions.offers import offer_cancel, offer_create
 from workload.transactions.nft import (
     nftoken_accept_offer,
     nftoken_burn,
@@ -394,6 +395,22 @@ def _on_amm_delete(w: Workload, tx: dict, meta: dict) -> None:
         )]
 
 
+def _on_offer_create(w: Workload, tx: dict, meta: dict) -> None:
+    offer_id = _extract_created_id(meta, "Offer")
+    if offer_id:
+        w.offers.append({
+            "account": tx.get("Account", ""),
+            "sequence": tx.get("Sequence", 0),
+            "offer_id": offer_id,
+        })
+
+
+def _on_offer_cancel(w: Workload, tx: dict, meta: dict) -> None:
+    deleted_id = _extract_deleted_id(meta, "Offer")
+    if deleted_id:
+        w.offers[:] = [o for o in w.offers if o.get("offer_id") != deleted_id]
+
+
 # ── Registry ─────────────────────────────────────────────────────────
 # (name, path, handler, args_fn, state_updater_or_None)
 
@@ -635,6 +652,20 @@ REGISTRY = [
         amm_delete,
         lambda w: (w.accounts, w.amms, w.client),
         _on_amm_delete,
+    ),
+    (
+        "OfferCreate",
+        "/offer/create/random",
+        offer_create,
+        lambda w: (w.accounts, w.amms, w.offers, w.trust_lines, w.client),
+        _on_offer_create,
+    ),
+    (
+        "OfferCancel",
+        "/offer/cancel/random",
+        offer_cancel,
+        lambda w: (w.accounts, w.offers, w.client),
+        _on_offer_cancel,
     ),
     (
         "LoanBrokerSet",

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -26,6 +26,7 @@ from xrpl.models.currencies import MPTCurrency
 
 from workload.models import (
     NFT,
+    AMM,
     Credential,
     Delegate,
     Loan,
@@ -37,6 +38,14 @@ from workload.models import (
     Vault,
 )
 from workload.transactions.account_set import account_set_random
+from workload.transactions.amm import (
+    amm_bid,
+    amm_create,
+    amm_delete,
+    amm_deposit,
+    amm_vote,
+    amm_withdraw,
+)
 from workload.transactions.batch import batch_random
 from workload.transactions.credentials import (
     credential_accept,
@@ -352,6 +361,39 @@ def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
     w.delegates.append(Delegate(source=source, delegate_address=delegate_addr, permissions=permissions))
 
 
+def _on_amm_create(w: Workload, tx: dict, meta: dict) -> None:
+    amm_id = _extract_created_id(meta, "AMM")
+    if amm_id:
+        # Parse both assets from the AMMCreate transaction
+        asset1_raw = tx.get("Amount", {})
+        asset2_raw = tx.get("Amount2", {})
+        assets = []
+        for raw in [asset1_raw, asset2_raw]:
+            if isinstance(raw, dict) and "currency" in raw:
+                assets.append(IssuedCurrency(currency=raw["currency"], issuer=raw.get("issuer", "")))
+            elif isinstance(raw, str):
+                assets.append(xrpl.models.XRP())
+        # Extract LP token from created AMM node
+        lp_token = []
+        for node in meta.get("AffectedNodes", []):
+            created = node.get("CreatedNode", {})
+            if created.get("LedgerEntryType") == "AMM":
+                lp_raw = created.get("NewFields", {}).get("LPTokenBalance", {})
+                if lp_raw and "currency" in lp_raw:
+                    lp_token.append(
+                        IssuedCurrency(currency=lp_raw["currency"], issuer=lp_raw.get("issuer", ""))
+                    )
+        w.amms.append(AMM(account=tx["Account"], assets=assets, lp_token=lp_token))
+
+
+def _on_amm_delete(w: Workload, tx: dict, meta: dict) -> None:
+    amm_id = _extract_deleted_id(meta, "AMM")
+    if amm_id:
+        w.amms[:] = [a for a in w.amms if not (
+            _extract_deleted_id(meta, "AMM") and a.account == tx.get("Account", "")
+        )]
+
+
 # ── Registry ─────────────────────────────────────────────────────────
 # (name, path, handler, args_fn, state_updater_or_None)
 
@@ -551,6 +593,48 @@ REGISTRY = [
         delegate_set,
         lambda w: (w.accounts, w.client),
         _on_delegate_set,
+    ),
+    (
+        "AMMCreate",
+        "/amm/create/random",
+        amm_create,
+        lambda w: (w.accounts, w.amms, w.trust_lines, w.client),
+        _on_amm_create,
+    ),
+    (
+        "AMMDeposit",
+        "/amm/deposit/random",
+        amm_deposit,
+        lambda w: (w.accounts, w.amms, w.client),
+        None,
+    ),
+    (
+        "AMMWithdraw",
+        "/amm/withdraw/random",
+        amm_withdraw,
+        lambda w: (w.accounts, w.amms, w.client),
+        None,
+    ),
+    (
+        "AMMVote",
+        "/amm/vote/random",
+        amm_vote,
+        lambda w: (w.accounts, w.amms, w.client),
+        None,
+    ),
+    (
+        "AMMBid",
+        "/amm/bid/random",
+        amm_bid,
+        lambda w: (w.accounts, w.amms, w.client),
+        None,
+    ),
+    (
+        "AMMDelete",
+        "/amm/delete/random",
+        amm_delete,
+        lambda w: (w.accounts, w.amms, w.client),
+        _on_amm_delete,
     ),
     (
         "LoanBrokerSet",

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -25,8 +25,8 @@ from xrpl.models import IssuedCurrency
 from xrpl.models.currencies import MPTCurrency
 
 from workload.models import (
-    NFT,
     AMM,
+    NFT,
     Credential,
     Delegate,
     Loan,
@@ -65,7 +65,6 @@ from workload.transactions.lending import (
     loan_set,
 )
 from workload.transactions.mpt import mpt_authorize, mpt_create, mpt_destroy, mpt_issuance_set
-from workload.transactions.offers import offer_cancel, offer_create
 from workload.transactions.nft import (
     nftoken_accept_offer,
     nftoken_burn,
@@ -74,6 +73,7 @@ from workload.transactions.nft import (
     nftoken_mint,
     nftoken_modify,
 )
+from workload.transactions.offers import offer_cancel, offer_create
 from workload.transactions.payments import payment_random
 from workload.transactions.tickets import ticket_create, ticket_use
 from workload.transactions.trustlines import trustline_create
@@ -356,10 +356,15 @@ def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
         return
     # Replace existing delegation from same source to same delegate
     w.delegates[:] = [
-        d for d in w.delegates
-        if not (d.source == source and d.delegate_address == delegate_addr)
+        d for d in w.delegates if not (d.source == source and d.delegate_address == delegate_addr)
     ]
-    w.delegates.append(Delegate(source=source, delegate_address=delegate_addr, permissions=permissions))
+    w.delegates.append(
+        Delegate(
+            source=source,
+            delegate_address=delegate_addr,
+            permissions=permissions,
+        )
+    )
 
 
 def _on_amm_create(w: Workload, tx: dict, meta: dict) -> None:
@@ -371,7 +376,12 @@ def _on_amm_create(w: Workload, tx: dict, meta: dict) -> None:
         assets = []
         for raw in [asset1_raw, asset2_raw]:
             if isinstance(raw, dict) and "currency" in raw:
-                assets.append(IssuedCurrency(currency=raw["currency"], issuer=raw.get("issuer", "")))
+                assets.append(
+                    IssuedCurrency(
+                        currency=raw["currency"],
+                        issuer=raw.get("issuer", ""),
+                    )
+                )
             elif isinstance(raw, str):
                 assets.append(xrpl.models.XRP())
         # Extract LP token from created AMM node
@@ -390,22 +400,31 @@ def _on_amm_create(w: Workload, tx: dict, meta: dict) -> None:
 def _on_amm_delete(w: Workload, tx: dict, meta: dict) -> None:
     amm_id = _extract_deleted_id(meta, "AMM")
     if amm_id:
-        w.amms[:] = [a for a in w.amms if not (
-            _extract_deleted_id(meta, "AMM") and a.account == tx.get("Account", "")
-        )]
+        # Match by asset pair — the deleter can be anyone, not just the creator.
+        tx_assets = {_parse_asset(tx.get("Asset", {})), _parse_asset(tx.get("Asset2", {}))}
+        w.amms[:] = [a for a in w.amms if set(a.assets) != tx_assets]
 
 
 def _on_offer_create(w: Workload, tx: dict, meta: dict) -> None:
     offer_id = _extract_created_id(meta, "Offer")
     if offer_id:
-        w.offers.append({
-            "account": tx.get("Account", ""),
-            "sequence": tx.get("Sequence", 0),
-            "offer_id": offer_id,
-        })
+        w.offers.append(
+            {
+                "account": tx.get("Account", ""),
+                "sequence": tx.get("Sequence", 0),
+                "offer_id": offer_id,
+            }
+        )
 
 
 def _on_offer_cancel(w: Workload, tx: dict, meta: dict) -> None:
+    """Remove an explicitly cancelled offer from state.
+
+    NOTE: offers also disappear via fill and expiry, which don't trigger
+    this handler. Stale entries will accumulate in w.offers — the cancel-valid
+    path may pick already-gone offers and get tecNO_OFFER. This is acceptable
+    for fuzzing purposes (exercises error paths).
+    """
     deleted_id = _extract_deleted_id(meta, "Offer")
     if deleted_id:
         w.offers[:] = [o for o in w.offers if o.get("offer_id") != deleted_id]
@@ -657,7 +676,7 @@ REGISTRY = [
         "OfferCreate",
         "/offer/create/random",
         offer_create,
-        lambda w: (w.accounts, w.amms, w.offers, w.trust_lines, w.client),
+        lambda w: (w.accounts, w.amms, w.trust_lines, w.client),
         _on_offer_create,
     ),
     (

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -1,0 +1,838 @@
+"""AMM transaction generators for the antithesis workload."""
+
+import xrpl.models
+from xrpl.asyncio.clients import AsyncJsonRpcClient
+from xrpl.models import IssuedCurrency
+from xrpl.models import IssuedCurrencyAmount as IOUAmount
+from xrpl.models.transactions import (
+    AMMBid,
+    AMMCreate,
+    AMMDelete,
+    AMMDeposit,
+    AMMVote,
+    AMMWithdraw,
+)
+from xrpl.models.transactions.amm_bid import AuthAccount
+from xrpl.models.transactions.amm_deposit import AMMDepositFlag
+from xrpl.models.transactions.amm_withdraw import AMMWithdrawFlag
+
+from workload import params
+from workload.models import AMM, TrustLine, UserAccount
+from workload.randoms import choice, randint, random, sample
+from workload.submit import submit_tx
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _pick_asset_pair(
+    trust_lines: list[TrustLine],
+) -> tuple[IssuedCurrency | xrpl.models.XRP, IssuedCurrency] | None:
+    """Pick a random asset pair for AMM creation.
+
+    Returns (asset1, asset2) where asset1 may be XRP and asset2 is always IOU.
+    Returns None if no trust lines exist.
+    """
+    if not trust_lines:
+        return None
+    tl = choice(trust_lines)
+    iou = IssuedCurrency(currency=tl.currency, issuer=tl.account_b)
+    if random() < 0.3:
+        return xrpl.models.XRP(), iou
+    # Pick a second different IOU
+    other_tls = [t for t in trust_lines if t.currency != tl.currency or t.account_b != tl.account_b]
+    if other_tls:
+        tl2 = choice(other_tls)
+        iou2 = IssuedCurrency(currency=tl2.currency, issuer=tl2.account_b)
+        return iou, iou2
+    return xrpl.models.XRP(), iou
+
+
+def _fake_iou() -> IssuedCurrency:
+    """Generate an IOU with a valid-format but non-existent issuer."""
+    return IssuedCurrency(currency=params.currency_code(), issuer=params.fake_account())
+
+
+def _iou_amount(asset: IssuedCurrency | xrpl.models.XRP, value: str) -> IOUAmount | str:
+    """Build an amount for the given asset. Returns drops string for XRP, IOUAmount for IOU."""
+    if isinstance(asset, xrpl.models.XRP):
+        return value
+    return IOUAmount(currency=asset.currency, issuer=asset.issuer, value=value)
+
+
+# ── AMMCreate ────────────────────────────────────────────────────────
+
+
+async def amm_create(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _amm_create_faulty(accounts, amms, trust_lines, client)
+    return await _amm_create_valid(accounts, amms, trust_lines, client)
+
+
+async def _amm_create_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts or not trust_lines:
+        return
+    pair = _pick_asset_pair(trust_lines)
+    if not pair:
+        return
+    asset1, asset2 = pair
+    src = choice(list(accounts.values()))
+    if isinstance(asset1, xrpl.models.XRP):
+        amount1 = params.amm_xrp_amount()
+    else:
+        amount1 = IOUAmount(currency=asset1.currency, issuer=asset1.issuer, value=params.amm_deposit_amount())
+    amount2 = IOUAmount(currency=asset2.currency, issuer=asset2.issuer, value=params.amm_deposit_amount())
+    txn = AMMCreate(
+        account=src.address,
+        amount=amount1,
+        amount2=amount2,
+        trading_fee=params.amm_trading_fee(),
+    )
+    await submit_tx("AMMCreate", txn, client, src.wallet)
+
+
+async def _amm_create_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+    mutation = choice([
+        "non_existent_asset", "same_asset_both", "fee_out_of_range",
+        "zero_amount", "negative_trading_fee",
+    ])
+
+    if mutation == "non_existent_asset":
+        amount1 = params.amm_xrp_amount()
+        fake = _fake_iou()
+        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        txn = AMMCreate(
+            account=src.address,
+            amount=amount1,
+            amount2=amount2,
+            trading_fee=params.amm_trading_fee(),
+        )
+
+    elif mutation == "same_asset_both":
+        if not trust_lines:
+            return
+        tl = choice(trust_lines)
+        iou = IssuedCurrency(currency=tl.currency, issuer=tl.account_b)
+        amount = IOUAmount(currency=iou.currency, issuer=iou.issuer, value=params.amm_deposit_amount())
+        txn = AMMCreate(
+            account=src.address,
+            amount=amount,
+            amount2=amount,
+            trading_fee=params.amm_trading_fee(),
+        )
+
+    elif mutation == "fee_out_of_range":
+        pair = _pick_asset_pair(trust_lines)
+        if not pair:
+            return
+        asset1, asset2 = pair
+        if isinstance(asset1, xrpl.models.XRP):
+            amount1 = params.amm_xrp_amount()
+        else:
+            amount1 = IOUAmount(currency=asset1.currency, issuer=asset1.issuer, value=params.amm_deposit_amount())
+        amount2 = IOUAmount(currency=asset2.currency, issuer=asset2.issuer, value=params.amm_deposit_amount())
+        txn = AMMCreate(
+            account=src.address,
+            amount=amount1,
+            amount2=amount2,
+            trading_fee=randint(1001, 65535),
+        )
+
+    elif mutation == "zero_amount":
+        fake = _fake_iou()
+        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value="0")
+        txn = AMMCreate(
+            account=src.address,
+            amount="0",
+            amount2=amount2,
+            trading_fee=params.amm_trading_fee(),
+        )
+
+    else:  # negative_trading_fee
+        fake = _fake_iou()
+        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        txn = AMMCreate(
+            account=src.address,
+            amount=params.amm_xrp_amount(),
+            amount2=amount2,
+            trading_fee=-1,
+        )
+
+    await submit_tx("AMMCreate", txn, client, src.wallet)
+
+
+# ── AMMDeposit ───────────────────────────────────────────────────────
+
+
+async def amm_deposit(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _amm_deposit_faulty(accounts, amms, client)
+    return await _amm_deposit_valid(accounts, amms, client)
+
+
+async def _amm_deposit_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts or not amms:
+        return
+    amm = choice(amms)
+    src = choice(list(accounts.values()))
+    if len(amm.assets) < 2:
+        return
+    asset1, asset2 = amm.assets[0], amm.assets[1]
+    mode = choice([
+        "single_asset", "two_asset", "lp_token",
+        "one_asset_lp_token", "limit_lp_token", "two_asset_if_empty",
+    ])
+
+    if mode == "single_asset":
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_deposit_amount())
+        txn = AMMDeposit(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, flags=AMMDepositFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mode == "two_asset":
+        amt1 = _iou_amount(asset1, params.amm_deposit_amount())
+        amt2 = _iou_amount(asset2, params.amm_deposit_amount())
+        txn = AMMDeposit(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amt1, amount2=amt2, flags=AMMDepositFlag.TF_TWO_ASSET,
+        )
+
+    elif mode == "lp_token":
+        if not amm.lp_token:
+            return
+        lp = amm.lp_token[0]
+        lp_out = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        txn = AMMDeposit(
+            account=src.address, asset=asset1, asset2=asset2,
+            lp_token_out=lp_out, flags=AMMDepositFlag.TF_LP_TOKEN,
+        )
+
+    elif mode == "one_asset_lp_token":
+        if not amm.lp_token:
+            return
+        lp = amm.lp_token[0]
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_deposit_amount())
+        lp_out = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        txn = AMMDeposit(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, lp_token_out=lp_out,
+            flags=AMMDepositFlag.TF_ONE_ASSET_LP_TOKEN,
+        )
+
+    elif mode == "limit_lp_token":
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_deposit_amount())
+        e_price = _iou_amount(a, str(randint(1, 1000)))
+        txn = AMMDeposit(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, e_price=e_price,
+            flags=AMMDepositFlag.TF_LIMIT_LP_TOKEN,
+        )
+
+    else:  # two_asset_if_empty
+        amt1 = _iou_amount(asset1, params.amm_deposit_amount())
+        amt2 = _iou_amount(asset2, params.amm_deposit_amount())
+        txn = AMMDeposit(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amt1, amount2=amt2,
+            flags=AMMDepositFlag.TF_TWO_ASSET_IF_EMPTY,
+        )
+
+    await submit_tx("AMMDeposit", txn, client, src.wallet)
+
+
+async def _amm_deposit_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+    mutation = choice([
+        "non_existent_amm", "zero_deposit", "wrong_asset",
+        "mismatched_flag_fields", "negative_amount",
+    ])
+
+    if mutation == "non_existent_amm":
+        fake = _fake_iou()
+        amount = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        txn = AMMDeposit(
+            account=src.address,
+            asset=xrpl.models.XRP(),
+            asset2=fake,
+            amount=amount,
+            flags=AMMDepositFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mutation == "zero_deposit":
+        if not amms:
+            return
+        amm = choice(amms)
+        asset = amm.assets[0] if amm.assets else None
+        if not asset:
+            return
+        amount = IOUAmount(currency=asset.currency, issuer=asset.issuer, value="0")
+        txn = AMMDeposit(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            amount=amount,
+            flags=AMMDepositFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mutation == "wrong_asset":
+        if not amms:
+            return
+        amm = choice(amms)
+        fake = _fake_iou()
+        amount = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        txn = AMMDeposit(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            amount=amount,
+            flags=AMMDepositFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mutation == "mismatched_flag_fields":
+        # TF_TWO_ASSET but only provide one amount — flag/field mismatch
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        amount = _iou_amount(amm.assets[0], params.amm_deposit_amount())
+        txn = AMMDeposit(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
+            amount=amount,
+            flags=AMMDepositFlag.TF_TWO_ASSET,
+        )
+
+    else:  # negative_amount
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        amount = _iou_amount(amm.assets[0], "-1")
+        txn = AMMDeposit(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
+            amount=amount,
+            flags=AMMDepositFlag.TF_SINGLE_ASSET,
+        )
+
+    await submit_tx("AMMDeposit", txn, client, src.wallet)
+
+
+# ── AMMWithdraw ──────────────────────────────────────────────────────
+
+
+async def amm_withdraw(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _amm_withdraw_faulty(accounts, amms, client)
+    return await _amm_withdraw_valid(accounts, amms, client)
+
+
+async def _amm_withdraw_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts or not amms:
+        return
+    amm = choice(amms)
+    src = choice(list(accounts.values()))
+    if len(amm.assets) < 2:
+        return
+    asset1, asset2 = amm.assets[0], amm.assets[1]
+    mode = choice([
+        "single_asset", "lp_token", "withdraw_all",
+        "one_asset_withdraw_all", "two_asset",
+        "one_asset_lp_token", "limit_lp_token",
+    ])
+
+    if mode == "single_asset":
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_withdraw_amount())
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mode == "lp_token":
+        if not amm.lp_token:
+            return
+        lp = amm.lp_token[0]
+        lp_in = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            lp_token_in=lp_in, flags=AMMWithdrawFlag.TF_LP_TOKEN,
+        )
+
+    elif mode == "withdraw_all":
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            flags=AMMWithdrawFlag.TF_WITHDRAW_ALL,
+        )
+
+    elif mode == "one_asset_withdraw_all":
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_withdraw_amount())
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, flags=AMMWithdrawFlag.TF_ONE_ASSET_WITHDRAW_ALL,
+        )
+
+    elif mode == "two_asset":
+        amt1 = _iou_amount(asset1, params.amm_withdraw_amount())
+        amt2 = _iou_amount(asset2, params.amm_withdraw_amount())
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amt1, amount2=amt2, flags=AMMWithdrawFlag.TF_TWO_ASSET,
+        )
+
+    elif mode == "one_asset_lp_token":
+        if not amm.lp_token:
+            return
+        lp = amm.lp_token[0]
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_withdraw_amount())
+        lp_in = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, lp_token_in=lp_in,
+            flags=AMMWithdrawFlag.TF_ONE_ASSET_LP_TOKEN,
+        )
+
+    else:  # limit_lp_token
+        a = choice([asset1, asset2])
+        amount = _iou_amount(a, params.amm_withdraw_amount())
+        e_price = _iou_amount(a, str(randint(1, 1000)))
+        txn = AMMWithdraw(
+            account=src.address, asset=asset1, asset2=asset2,
+            amount=amount, e_price=e_price,
+            flags=AMMWithdrawFlag.TF_LIMIT_LP_TOKEN,
+        )
+
+    await submit_tx("AMMWithdraw", txn, client, src.wallet)
+
+
+async def _amm_withdraw_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+    mutation = choice([
+        "non_existent_amm", "zero_withdrawal", "overdraw",
+        "mismatched_flag_fields", "negative_amount",
+    ])
+
+    if mutation == "non_existent_amm":
+        fake = _fake_iou()
+        amount = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_withdraw_amount())
+        txn = AMMWithdraw(
+            account=src.address,
+            asset=xrpl.models.XRP(),
+            asset2=fake,
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mutation == "zero_withdrawal":
+        if not amms:
+            return
+        amm = choice(amms)
+        asset = amm.assets[0] if amm.assets else None
+        if not asset:
+            return
+        amount = IOUAmount(currency=asset.currency, issuer=asset.issuer, value="0")
+        txn = AMMWithdraw(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mutation == "overdraw":
+        if not amms:
+            return
+        amm = choice(amms)
+        asset = amm.assets[0] if amm.assets else None
+        if not asset:
+            return
+        amount = IOUAmount(
+            currency=asset.currency,
+            issuer=asset.issuer,
+            value=str(10**18),
+        )
+        txn = AMMWithdraw(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
+        )
+
+    elif mutation == "mismatched_flag_fields":
+        # TF_TWO_ASSET but only provide one amount — flag/field mismatch
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        amount = _iou_amount(amm.assets[0], params.amm_withdraw_amount())
+        txn = AMMWithdraw(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_TWO_ASSET,
+        )
+
+    else:  # negative_amount
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        amount = _iou_amount(amm.assets[0], "-1")
+        txn = AMMWithdraw(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
+        )
+
+    await submit_tx("AMMWithdraw", txn, client, src.wallet)
+
+
+# ── AMMVote ──────────────────────────────────────────────────────────
+
+
+async def amm_vote(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _amm_vote_faulty(accounts, amms, client)
+    return await _amm_vote_valid(accounts, amms, client)
+
+
+async def _amm_vote_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts or not amms:
+        return
+    amm = choice(amms)
+    src = choice(list(accounts.values()))
+    txn = AMMVote(
+        account=src.address,
+        asset=amm.assets[0],
+        asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+        trading_fee=params.amm_vote_fee(),
+    )
+    await submit_tx("AMMVote", txn, client, src.wallet)
+
+
+async def _amm_vote_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+    mutation = choice(["non_existent_amm", "fee_out_of_range", "negative_fee"])
+
+    if mutation == "non_existent_amm":
+        fake = _fake_iou()
+        txn = AMMVote(
+            account=src.address,
+            asset=xrpl.models.XRP(),
+            asset2=fake,
+            trading_fee=params.amm_vote_fee(),
+        )
+
+    elif mutation == "fee_out_of_range":
+        if not amms:
+            return
+        amm = choice(amms)
+        txn = AMMVote(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            trading_fee=randint(1001, 65535),
+        )
+
+    else:  # negative_fee
+        if not amms:
+            return
+        amm = choice(amms)
+        txn = AMMVote(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            trading_fee=-1,
+        )
+
+    await submit_tx("AMMVote", txn, client, src.wallet)
+
+
+# ── AMMBid ───────────────────────────────────────────────────────────
+
+
+async def amm_bid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _amm_bid_faulty(accounts, amms, client)
+    return await _amm_bid_valid(accounts, amms, client)
+
+
+async def _amm_bid_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts or not amms:
+        return
+    amm = choice(amms)
+    if not amm.lp_token or len(amm.assets) < 2:
+        return
+    src = choice(list(accounts.values()))
+    lp = amm.lp_token[0]
+    mode = choice(["basic_bid", "bid_with_auth_accounts"])
+
+    if mode == "basic_bid":
+        bid_min = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
+        bid_max = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_max())
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0], asset2=amm.assets[1],
+            bid_min=bid_min, bid_max=bid_max,
+        )
+
+    else:  # bid_with_auth_accounts
+        acct_list = list(accounts.values())
+        num_auth = randint(1, min(4, len(acct_list)))
+        auth_accounts = [AuthAccount(account=a.address) for a in sample(acct_list, num_auth)]
+        bid_min = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0], asset2=amm.assets[1],
+            bid_min=bid_min,
+            auth_accounts=auth_accounts,
+        )
+
+    await submit_tx("AMMBid", txn, client, src.wallet)
+
+
+async def _amm_bid_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+    mutation = choice([
+        "non_existent_amm", "zero_bid",
+        "bid_min_exceeds_max", "too_many_auth_accounts", "fake_auth_accounts",
+    ])
+
+    if mutation == "non_existent_amm":
+        fake = _fake_iou()
+        bid_amt = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_bid_min())
+        txn = AMMBid(
+            account=src.address,
+            asset=xrpl.models.XRP(),
+            asset2=fake,
+            bid_min=bid_amt,
+        )
+
+    elif mutation == "zero_bid":
+        if not amms:
+            return
+        amm = choice(amms)
+        if not amm.lp_token:
+            return
+        lp = amm.lp_token[0]
+        bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value="0")
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            bid_min=bid_amt,
+        )
+
+    elif mutation == "bid_min_exceeds_max":
+        if not amms:
+            return
+        amm = choice(amms)
+        if not amm.lp_token or len(amm.assets) < 2:
+            return
+        lp = amm.lp_token[0]
+        bid_min = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_max())
+        bid_max = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0], asset2=amm.assets[1],
+            bid_min=bid_min, bid_max=bid_max,
+        )
+
+    elif mutation == "too_many_auth_accounts":
+        if not amms:
+            return
+        amm = choice(amms)
+        if not amm.lp_token or len(amm.assets) < 2:
+            return
+        lp = amm.lp_token[0]
+        acct_list = list(accounts.values())
+        num_auth = randint(5, min(8, len(acct_list)))
+        auth_accounts = [AuthAccount(account=a.address) for a in sample(acct_list, num_auth)]
+        bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0], asset2=amm.assets[1],
+            bid_min=bid_amt,
+            auth_accounts=auth_accounts,
+        )
+
+    else:  # fake_auth_accounts
+        if not amms:
+            return
+        amm = choice(amms)
+        if not amm.lp_token or len(amm.assets) < 2:
+            return
+        lp = amm.lp_token[0]
+        fake_auths = [AuthAccount(account=params.fake_account()) for _ in range(randint(1, 4))]
+        bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0], asset2=amm.assets[1],
+            bid_min=bid_amt,
+            auth_accounts=fake_auths,
+        )
+
+    await submit_tx("AMMBid", txn, client, src.wallet)
+
+
+# ── AMMDelete ────────────────────────────────────────────────────────
+
+
+async def amm_delete(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _amm_delete_faulty(accounts, amms, client)
+    return await _amm_delete_valid(accounts, amms, client)
+
+
+async def _amm_delete_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts or not amms:
+        return
+    amm = choice(amms)
+    src = choice(list(accounts.values()))
+    txn = AMMDelete(
+        account=src.address,
+        asset=amm.assets[0],
+        asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+    )
+    await submit_tx("AMMDelete", txn, client, src.wallet)
+
+
+async def _amm_delete_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+    mutation = choice(["non_existent_amm", "non_empty_amm", "wrong_asset_pair"])
+
+    if mutation == "non_existent_amm":
+        fake = _fake_iou()
+        txn = AMMDelete(
+            account=src.address,
+            asset=xrpl.models.XRP(),
+            asset2=fake,
+        )
+
+    elif mutation == "non_empty_amm":
+        if not amms:
+            return
+        amm = choice(amms)
+        txn = AMMDelete(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+        )
+
+    else:  # wrong_asset_pair — use real assets but wrong combination
+        if not amms:
+            return
+        amm = choice(amms)
+        fake = _fake_iou()
+        # Swap one real asset with a fake one
+        txn = AMMDelete(
+            account=src.address,
+            asset=amm.assets[0],
+            asset2=fake,
+        )
+
+    await submit_tx("AMMDelete", txn, client, src.wallet)

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -22,6 +22,7 @@ from workload.randoms import choice, randint, random, sample
 from workload.submit import submit_tx
 
 
+
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
@@ -111,8 +112,8 @@ async def _amm_create_faulty(
         return
     src = choice(list(accounts.values()))
     mutation = choice([
-        "non_existent_asset", "same_asset_both", "fee_out_of_range",
-        "zero_amount", "negative_trading_fee",
+        "non_existent_asset", "same_asset_both",
+        "zero_amount", "duplicate_amm", "unfunded_create",
     ])
 
     if mutation == "non_existent_asset":
@@ -139,23 +140,6 @@ async def _amm_create_faulty(
             trading_fee=params.amm_trading_fee(),
         )
 
-    elif mutation == "fee_out_of_range":
-        pair = _pick_asset_pair(trust_lines)
-        if not pair:
-            return
-        asset1, asset2 = pair
-        if isinstance(asset1, xrpl.models.XRP):
-            amount1 = params.amm_xrp_amount()
-        else:
-            amount1 = IOUAmount(currency=asset1.currency, issuer=asset1.issuer, value=params.amm_deposit_amount())
-        amount2 = IOUAmount(currency=asset2.currency, issuer=asset2.issuer, value=params.amm_deposit_amount())
-        txn = AMMCreate(
-            account=src.address,
-            amount=amount1,
-            amount2=amount2,
-            trading_fee=randint(1001, 65535),
-        )
-
     elif mutation == "zero_amount":
         fake = _fake_iou()
         amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value="0")
@@ -166,14 +150,38 @@ async def _amm_create_faulty(
             trading_fee=params.amm_trading_fee(),
         )
 
-    else:  # negative_trading_fee
-        fake = _fake_iou()
-        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+    elif mutation == "duplicate_amm":
+        # Try to create an AMM for an asset pair that already exists (tecDUPLICATE)
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        a1, a2 = amm.assets[0], amm.assets[1]
+        if isinstance(a1, xrpl.models.XRP):
+            amount1 = params.amm_xrp_amount()
+        else:
+            amount1 = IOUAmount(currency=a1.currency, issuer=a1.issuer, value=params.amm_deposit_amount())
+        if isinstance(a2, xrpl.models.XRP):
+            amount2 = params.amm_xrp_amount()
+        else:
+            amount2 = IOUAmount(currency=a2.currency, issuer=a2.issuer, value=params.amm_deposit_amount())
         txn = AMMCreate(
             account=src.address,
-            amount=params.amm_xrp_amount(),
+            amount=amount1,
             amount2=amount2,
-            trading_fee=-1,
+            trading_fee=params.amm_trading_fee(),
+        )
+
+    else:  # unfunded_create
+        # Create with assets the account doesn't hold (tecUNFUNDED_AMM)
+        fake = _fake_iou()
+        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=str(randint(1_000_000, 999_999_999)))
+        txn = AMMCreate(
+            account=src.address,
+            amount=str(randint(10_000_000_000, 99_000_000_000)),  # more XRP than account has
+            amount2=amount2,
+            trading_fee=params.amm_trading_fee(),
         )
 
     await submit_tx("AMMCreate", txn, client, src.wallet)
@@ -301,7 +309,7 @@ async def _amm_deposit_faulty(
         asset = amm.assets[0] if amm.assets else None
         if not asset:
             return
-        amount = IOUAmount(currency=asset.currency, issuer=asset.issuer, value="0")
+        amount = _iou_amount(asset, "0")
         txn = AMMDeposit(
             account=src.address,
             asset=amm.assets[0],
@@ -346,7 +354,9 @@ async def _amm_deposit_faulty(
         amm = choice(amms)
         if len(amm.assets) < 2:
             return
-        amount = _iou_amount(amm.assets[0], "-1")
+        # Use IOU asset to avoid XRP codec rejection of negative drops
+        asset = amm.assets[1] if isinstance(amm.assets[0], xrpl.models.XRP) else amm.assets[0]
+        amount = IOUAmount(currency=asset.currency, issuer=asset.issuer, value="-1")
         txn = AMMDeposit(
             account=src.address,
             asset=amm.assets[0],
@@ -486,7 +496,7 @@ async def _amm_withdraw_faulty(
         asset = amm.assets[0] if amm.assets else None
         if not asset:
             return
-        amount = IOUAmount(currency=asset.currency, issuer=asset.issuer, value="0")
+        amount = _iou_amount(asset, "0")
         txn = AMMWithdraw(
             account=src.address,
             asset=amm.assets[0],
@@ -499,18 +509,19 @@ async def _amm_withdraw_faulty(
         if not amms:
             return
         amm = choice(amms)
-        asset = amm.assets[0] if amm.assets else None
-        if not asset:
+        if len(amm.assets) < 2:
             return
+        # Use IOU asset to avoid XRP issuer issue
+        asset = amm.assets[1] if isinstance(amm.assets[0], xrpl.models.XRP) else amm.assets[0]
         amount = IOUAmount(
             currency=asset.currency,
             issuer=asset.issuer,
-            value=str(10**18),
+            value=str(10**15),  # within IOU precision but far exceeds pool balance
         )
         txn = AMMWithdraw(
             account=src.address,
             asset=amm.assets[0],
-            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
+            asset2=amm.assets[1],
             amount=amount,
             flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
         )
@@ -537,7 +548,9 @@ async def _amm_withdraw_faulty(
         amm = choice(amms)
         if len(amm.assets) < 2:
             return
-        amount = _iou_amount(amm.assets[0], "-1")
+        # Use IOU asset to avoid XRP codec rejection of negative drops
+        asset = amm.assets[1] if isinstance(amm.assets[0], xrpl.models.XRP) else amm.assets[0]
+        amount = IOUAmount(currency=asset.currency, issuer=asset.issuer, value="-1")
         txn = AMMWithdraw(
             account=src.address,
             asset=amm.assets[0],
@@ -588,7 +601,7 @@ async def _amm_vote_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice(["non_existent_amm", "fee_out_of_range", "negative_fee"])
+    mutation = choice(["non_existent_amm", "non_lp_holder_vote", "swapped_assets"])
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
@@ -599,7 +612,8 @@ async def _amm_vote_faulty(
             trading_fee=params.amm_vote_fee(),
         )
 
-    elif mutation == "fee_out_of_range":
+    elif mutation == "non_lp_holder_vote":
+        # Vote on a real AMM without holding LP tokens (tecAMM_FAILED)
         if not amms:
             return
         amm = choice(amms)
@@ -607,18 +621,21 @@ async def _amm_vote_faulty(
             account=src.address,
             asset=amm.assets[0],
             asset2=amm.assets[1] if len(amm.assets) > 1 else None,
-            trading_fee=randint(1001, 65535),
+            trading_fee=params.amm_vote_fee(),
         )
 
-    else:  # negative_fee
+    else:  # swapped_assets
+        # Vote with asset1/asset2 swapped (tecAMM_INVALID_TOKENS)
         if not amms:
             return
         amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
         txn = AMMVote(
             account=src.address,
-            asset=amm.assets[0],
-            asset2=amm.assets[1] if len(amm.assets) > 1 else None,
-            trading_fee=-1,
+            asset=amm.assets[1],
+            asset2=amm.assets[0],
+            trading_fee=params.amm_vote_fee(),
         )
 
     await submit_tx("AMMVote", txn, client, src.wallet)
@@ -685,7 +702,7 @@ async def _amm_bid_faulty(
     src = choice(list(accounts.values()))
     mutation = choice([
         "non_existent_amm", "zero_bid",
-        "bid_min_exceeds_max", "too_many_auth_accounts", "fake_auth_accounts",
+        "bid_min_exceeds_max", "fake_auth_accounts", "non_lp_holder_bid",
     ])
 
     if mutation == "non_existent_amm":
@@ -728,25 +745,7 @@ async def _amm_bid_faulty(
             bid_min=bid_min, bid_max=bid_max,
         )
 
-    elif mutation == "too_many_auth_accounts":
-        if not amms:
-            return
-        amm = choice(amms)
-        if not amm.lp_token or len(amm.assets) < 2:
-            return
-        lp = amm.lp_token[0]
-        acct_list = list(accounts.values())
-        num_auth = randint(5, min(8, len(acct_list)))
-        auth_accounts = [AuthAccount(account=a.address) for a in sample(acct_list, num_auth)]
-        bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
-        txn = AMMBid(
-            account=src.address,
-            asset=amm.assets[0], asset2=amm.assets[1],
-            bid_min=bid_amt,
-            auth_accounts=auth_accounts,
-        )
-
-    else:  # fake_auth_accounts
+    elif mutation == "fake_auth_accounts":
         if not amms:
             return
         amm = choice(amms)
@@ -760,6 +759,21 @@ async def _amm_bid_faulty(
             asset=amm.assets[0], asset2=amm.assets[1],
             bid_min=bid_amt,
             auth_accounts=fake_auths,
+        )
+
+    else:  # non_lp_holder_bid
+        # Bid on a real AMM without holding LP tokens (tecAMM_INVALID_TOKENS)
+        if not amms:
+            return
+        amm = choice(amms)
+        if not amm.lp_token or len(amm.assets) < 2:
+            return
+        lp = amm.lp_token[0]
+        bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
+        txn = AMMBid(
+            account=src.address,
+            asset=amm.assets[0], asset2=amm.assets[1],
+            bid_min=bid_amt,
         )
 
     await submit_tx("AMMBid", txn, client, src.wallet)

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -21,7 +21,37 @@ from workload.models import AMM, TrustLine, UserAccount
 from workload.randoms import choice, randint, random, sample
 from workload.submit import submit_tx
 
+
 # ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _find_account_with_trust_lines(
+    accounts: dict[str, UserAccount],
+    trust_lines: list[TrustLine],
+    needed_ious: list[IssuedCurrency],
+) -> UserAccount | None:
+    """Find an account that has trust lines for all needed IOUs.
+
+    Accounts with trust lines received IOU distributions during setup,
+    so having the trust line implies having balance.
+    Returns None if no eligible account exists.
+    """
+    if not needed_ious:
+        return choice(list(accounts.values()))
+
+    tl_by_account: dict[str, set[tuple[str, str]]] = {}
+    for tl in trust_lines:
+        tl_by_account.setdefault(tl.account_a, set()).add((tl.currency, tl.account_b))
+
+    eligible = []
+    for addr, acct in accounts.items():
+        acct_tls = tl_by_account.get(addr, set())
+        if all((iou.currency, iou.issuer) in acct_tls for iou in needed_ious):
+            eligible.append(acct)
+
+    if not eligible:
+        return None
+    return choice(eligible)
 
 
 def _pick_asset_pair(
@@ -85,7 +115,11 @@ async def _amm_create_valid(
     if not pair:
         return
     asset1, asset2 = pair
-    src = choice(list(accounts.values()))
+    # Find account that holds the needed IOUs
+    needed = [a for a in [asset1, asset2] if not isinstance(a, xrpl.models.XRP)]
+    src = _find_account_with_trust_lines(accounts, trust_lines, needed)
+    if not src:
+        return
     if isinstance(asset1, xrpl.models.XRP):
         amount1 = params.amm_xrp_amount()
     else:
@@ -566,22 +600,28 @@ async def _amm_withdraw_faulty(
 async def amm_vote(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
+    trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
         return await _amm_vote_faulty(accounts, amms, client)
-    return await _amm_vote_valid(accounts, amms, client)
+    return await _amm_vote_valid(accounts, amms, trust_lines, client)
 
 
 async def _amm_vote_valid(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
+    trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts or not amms:
         return
     amm = choice(amms)
-    src = choice(list(accounts.values()))
+    # Pick account that holds the AMM's IOU assets (likely LP token holder)
+    needed = [a for a in amm.assets if not isinstance(a, xrpl.models.XRP)]
+    src = _find_account_with_trust_lines(accounts, trust_lines, needed)
+    if not src:
+        return
     txn = AMMVote(
         account=src.address,
         asset=amm.assets[0],

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -21,8 +21,6 @@ from workload.models import AMM, TrustLine, UserAccount
 from workload.randoms import choice, randint, random, sample
 from workload.submit import submit_tx
 
-
-
 # ── Helpers ──────────────────────────────────────────────────────────
 
 

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -21,7 +21,6 @@ from workload.models import AMM, TrustLine, UserAccount
 from workload.randoms import choice, randint, random, sample
 from workload.submit import submit_tx
 
-
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
@@ -123,8 +122,16 @@ async def _amm_create_valid(
     if isinstance(asset1, xrpl.models.XRP):
         amount1 = params.amm_xrp_amount()
     else:
-        amount1 = IOUAmount(currency=asset1.currency, issuer=asset1.issuer, value=params.amm_deposit_amount())
-    amount2 = IOUAmount(currency=asset2.currency, issuer=asset2.issuer, value=params.amm_deposit_amount())
+        amount1 = IOUAmount(
+            currency=asset1.currency,
+            issuer=asset1.issuer,
+            value=params.amm_deposit_amount(),
+        )
+    amount2 = IOUAmount(
+        currency=asset2.currency,
+        issuer=asset2.issuer,
+        value=params.amm_deposit_amount(),
+    )
     txn = AMMCreate(
         account=src.address,
         amount=amount1,
@@ -143,15 +150,24 @@ async def _amm_create_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice([
-        "non_existent_asset", "same_asset_both",
-        "zero_amount", "duplicate_amm", "unfunded_create",
-    ])
+    mutation = choice(
+        [
+            "non_existent_asset",
+            "same_asset_both",
+            "zero_amount",
+            "duplicate_amm",
+            "unfunded_create",
+        ]
+    )
 
     if mutation == "non_existent_asset":
         amount1 = params.amm_xrp_amount()
         fake = _fake_iou()
-        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        amount2 = IOUAmount(
+            currency=fake.currency,
+            issuer=fake.issuer,
+            value=params.amm_deposit_amount(),
+        )
         txn = AMMCreate(
             account=src.address,
             amount=amount1,
@@ -164,7 +180,11 @@ async def _amm_create_faulty(
             return
         tl = choice(trust_lines)
         iou = IssuedCurrency(currency=tl.currency, issuer=tl.account_b)
-        amount = IOUAmount(currency=iou.currency, issuer=iou.issuer, value=params.amm_deposit_amount())
+        amount = IOUAmount(
+            currency=iou.currency,
+            issuer=iou.issuer,
+            value=params.amm_deposit_amount(),
+        )
         txn = AMMCreate(
             account=src.address,
             amount=amount,
@@ -193,11 +213,19 @@ async def _amm_create_faulty(
         if isinstance(a1, xrpl.models.XRP):
             amount1 = params.amm_xrp_amount()
         else:
-            amount1 = IOUAmount(currency=a1.currency, issuer=a1.issuer, value=params.amm_deposit_amount())
+            amount1 = IOUAmount(
+                currency=a1.currency,
+                issuer=a1.issuer,
+                value=params.amm_deposit_amount(),
+            )
         if isinstance(a2, xrpl.models.XRP):
             amount2 = params.amm_xrp_amount()
         else:
-            amount2 = IOUAmount(currency=a2.currency, issuer=a2.issuer, value=params.amm_deposit_amount())
+            amount2 = IOUAmount(
+                currency=a2.currency,
+                issuer=a2.issuer,
+                value=params.amm_deposit_amount(),
+            )
         txn = AMMCreate(
             account=src.address,
             amount=amount1,
@@ -208,7 +236,11 @@ async def _amm_create_faulty(
     else:  # unfunded_create
         # Create with assets the account doesn't hold (tecUNFUNDED_AMM)
         fake = _fake_iou()
-        amount2 = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=str(randint(1_000_000, 999_999_999)))
+        amount2 = IOUAmount(
+            currency=fake.currency,
+            issuer=fake.issuer,
+            value=str(randint(1_000_000, 999_999_999)),
+        )
         txn = AMMCreate(
             account=src.address,
             amount=str(randint(10_000_000_000, 99_000_000_000)),  # more XRP than account has
@@ -244,35 +276,55 @@ async def _amm_deposit_valid(
     if len(amm.assets) < 2:
         return
     asset1, asset2 = amm.assets[0], amm.assets[1]
-    mode = choice([
-        "single_asset", "two_asset", "lp_token",
-        "one_asset_lp_token", "limit_lp_token", "two_asset_if_empty",
-    ])
+    mode = choice(
+        [
+            "single_asset",
+            "two_asset",
+            "lp_token",
+            "one_asset_lp_token",
+            "limit_lp_token",
+            "two_asset_if_empty",
+        ]
+    )
 
     if mode == "single_asset":
         a = choice([asset1, asset2])
         amount = _iou_amount(a, params.amm_deposit_amount())
         txn = AMMDeposit(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, flags=AMMDepositFlag.TF_SINGLE_ASSET,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            flags=AMMDepositFlag.TF_SINGLE_ASSET,
         )
 
     elif mode == "two_asset":
         amt1 = _iou_amount(asset1, params.amm_deposit_amount())
         amt2 = _iou_amount(asset2, params.amm_deposit_amount())
         txn = AMMDeposit(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amt1, amount2=amt2, flags=AMMDepositFlag.TF_TWO_ASSET,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amt1,
+            amount2=amt2,
+            flags=AMMDepositFlag.TF_TWO_ASSET,
         )
 
     elif mode == "lp_token":
         if not amm.lp_token:
             return
         lp = amm.lp_token[0]
-        lp_out = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        lp_out = IOUAmount(
+            currency=lp.currency,
+            issuer=lp.issuer,
+            value=params.amm_lp_token_amount(),
+        )
         txn = AMMDeposit(
-            account=src.address, asset=asset1, asset2=asset2,
-            lp_token_out=lp_out, flags=AMMDepositFlag.TF_LP_TOKEN,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            lp_token_out=lp_out,
+            flags=AMMDepositFlag.TF_LP_TOKEN,
         )
 
     elif mode == "one_asset_lp_token":
@@ -281,10 +333,17 @@ async def _amm_deposit_valid(
         lp = amm.lp_token[0]
         a = choice([asset1, asset2])
         amount = _iou_amount(a, params.amm_deposit_amount())
-        lp_out = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        lp_out = IOUAmount(
+            currency=lp.currency,
+            issuer=lp.issuer,
+            value=params.amm_lp_token_amount(),
+        )
         txn = AMMDeposit(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, lp_token_out=lp_out,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            lp_token_out=lp_out,
             flags=AMMDepositFlag.TF_ONE_ASSET_LP_TOKEN,
         )
 
@@ -293,8 +352,11 @@ async def _amm_deposit_valid(
         amount = _iou_amount(a, params.amm_deposit_amount())
         e_price = _iou_amount(a, str(randint(1, 1000)))
         txn = AMMDeposit(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, e_price=e_price,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            e_price=e_price,
             flags=AMMDepositFlag.TF_LIMIT_LP_TOKEN,
         )
 
@@ -302,8 +364,11 @@ async def _amm_deposit_valid(
         amt1 = _iou_amount(asset1, params.amm_deposit_amount())
         amt2 = _iou_amount(asset2, params.amm_deposit_amount())
         txn = AMMDeposit(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amt1, amount2=amt2,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amt1,
+            amount2=amt2,
             flags=AMMDepositFlag.TF_TWO_ASSET_IF_EMPTY,
         )
 
@@ -318,14 +383,23 @@ async def _amm_deposit_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice([
-        "non_existent_amm", "zero_deposit", "wrong_asset",
-        "mismatched_flag_fields", "negative_amount",
-    ])
+    mutation = choice(
+        [
+            "non_existent_amm",
+            "zero_deposit",
+            "wrong_asset",
+            "mismatched_flag_fields",
+            "negative_amount",
+        ]
+    )
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
-        amount = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        amount = IOUAmount(
+            currency=fake.currency,
+            issuer=fake.issuer,
+            value=params.amm_deposit_amount(),
+        )
         txn = AMMDeposit(
             account=src.address,
             asset=xrpl.models.XRP(),
@@ -355,7 +429,11 @@ async def _amm_deposit_faulty(
             return
         amm = choice(amms)
         fake = _fake_iou()
-        amount = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_deposit_amount())
+        amount = IOUAmount(
+            currency=fake.currency,
+            issuer=fake.issuer,
+            value=params.amm_deposit_amount(),
+        )
         txn = AMMDeposit(
             account=src.address,
             asset=amm.assets[0],
@@ -425,33 +503,51 @@ async def _amm_withdraw_valid(
     if len(amm.assets) < 2:
         return
     asset1, asset2 = amm.assets[0], amm.assets[1]
-    mode = choice([
-        "single_asset", "lp_token", "withdraw_all",
-        "one_asset_withdraw_all", "two_asset",
-        "one_asset_lp_token", "limit_lp_token",
-    ])
+    mode = choice(
+        [
+            "single_asset",
+            "lp_token",
+            "withdraw_all",
+            "one_asset_withdraw_all",
+            "two_asset",
+            "one_asset_lp_token",
+            "limit_lp_token",
+        ]
+    )
 
     if mode == "single_asset":
         a = choice([asset1, asset2])
         amount = _iou_amount(a, params.amm_withdraw_amount())
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_SINGLE_ASSET,
         )
 
     elif mode == "lp_token":
         if not amm.lp_token:
             return
         lp = amm.lp_token[0]
-        lp_in = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        lp_in = IOUAmount(
+            currency=lp.currency,
+            issuer=lp.issuer,
+            value=params.amm_lp_token_amount(),
+        )
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
-            lp_token_in=lp_in, flags=AMMWithdrawFlag.TF_LP_TOKEN,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            lp_token_in=lp_in,
+            flags=AMMWithdrawFlag.TF_LP_TOKEN,
         )
 
     elif mode == "withdraw_all":
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
             flags=AMMWithdrawFlag.TF_WITHDRAW_ALL,
         )
 
@@ -459,16 +555,23 @@ async def _amm_withdraw_valid(
         a = choice([asset1, asset2])
         amount = _iou_amount(a, params.amm_withdraw_amount())
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, flags=AMMWithdrawFlag.TF_ONE_ASSET_WITHDRAW_ALL,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            flags=AMMWithdrawFlag.TF_ONE_ASSET_WITHDRAW_ALL,
         )
 
     elif mode == "two_asset":
         amt1 = _iou_amount(asset1, params.amm_withdraw_amount())
         amt2 = _iou_amount(asset2, params.amm_withdraw_amount())
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amt1, amount2=amt2, flags=AMMWithdrawFlag.TF_TWO_ASSET,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amt1,
+            amount2=amt2,
+            flags=AMMWithdrawFlag.TF_TWO_ASSET,
         )
 
     elif mode == "one_asset_lp_token":
@@ -477,10 +580,17 @@ async def _amm_withdraw_valid(
         lp = amm.lp_token[0]
         a = choice([asset1, asset2])
         amount = _iou_amount(a, params.amm_withdraw_amount())
-        lp_in = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_lp_token_amount())
+        lp_in = IOUAmount(
+            currency=lp.currency,
+            issuer=lp.issuer,
+            value=params.amm_lp_token_amount(),
+        )
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, lp_token_in=lp_in,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            lp_token_in=lp_in,
             flags=AMMWithdrawFlag.TF_ONE_ASSET_LP_TOKEN,
         )
 
@@ -489,8 +599,11 @@ async def _amm_withdraw_valid(
         amount = _iou_amount(a, params.amm_withdraw_amount())
         e_price = _iou_amount(a, str(randint(1, 1000)))
         txn = AMMWithdraw(
-            account=src.address, asset=asset1, asset2=asset2,
-            amount=amount, e_price=e_price,
+            account=src.address,
+            asset=asset1,
+            asset2=asset2,
+            amount=amount,
+            e_price=e_price,
             flags=AMMWithdrawFlag.TF_LIMIT_LP_TOKEN,
         )
 
@@ -505,14 +618,23 @@ async def _amm_withdraw_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice([
-        "non_existent_amm", "zero_withdrawal", "overdraw",
-        "mismatched_flag_fields", "negative_amount",
-    ])
+    mutation = choice(
+        [
+            "non_existent_amm",
+            "zero_withdrawal",
+            "overdraw",
+            "mismatched_flag_fields",
+            "negative_amount",
+        ]
+    )
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
-        amount = IOUAmount(currency=fake.currency, issuer=fake.issuer, value=params.amm_withdraw_amount())
+        amount = IOUAmount(
+            currency=fake.currency,
+            issuer=fake.issuer,
+            value=params.amm_withdraw_amount(),
+        )
         txn = AMMWithdraw(
             account=src.address,
             asset=xrpl.models.XRP(),
@@ -711,8 +833,10 @@ async def _amm_bid_valid(
         bid_max = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_max())
         txn = AMMBid(
             account=src.address,
-            asset=amm.assets[0], asset2=amm.assets[1],
-            bid_min=bid_min, bid_max=bid_max,
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
+            bid_min=bid_min,
+            bid_max=bid_max,
         )
 
     else:  # bid_with_auth_accounts
@@ -722,7 +846,8 @@ async def _amm_bid_valid(
         bid_min = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
         txn = AMMBid(
             account=src.address,
-            asset=amm.assets[0], asset2=amm.assets[1],
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
             bid_min=bid_min,
             auth_accounts=auth_accounts,
         )
@@ -738,10 +863,15 @@ async def _amm_bid_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice([
-        "non_existent_amm", "zero_bid",
-        "bid_min_exceeds_max", "fake_auth_accounts", "non_lp_holder_bid",
-    ])
+    mutation = choice(
+        [
+            "non_existent_amm",
+            "zero_bid",
+            "bid_min_exceeds_max",
+            "fake_auth_accounts",
+            "non_lp_holder_bid",
+        ]
+    )
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
@@ -779,8 +909,10 @@ async def _amm_bid_faulty(
         bid_max = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
         txn = AMMBid(
             account=src.address,
-            asset=amm.assets[0], asset2=amm.assets[1],
-            bid_min=bid_min, bid_max=bid_max,
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
+            bid_min=bid_min,
+            bid_max=bid_max,
         )
 
     elif mutation == "fake_auth_accounts":
@@ -794,7 +926,8 @@ async def _amm_bid_faulty(
         bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
         txn = AMMBid(
             account=src.address,
-            asset=amm.assets[0], asset2=amm.assets[1],
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
             bid_min=bid_amt,
             auth_accounts=fake_auths,
         )
@@ -810,7 +943,8 @@ async def _amm_bid_faulty(
         bid_amt = IOUAmount(currency=lp.currency, issuer=lp.issuer, value=params.amm_bid_min())
         txn = AMMBid(
             account=src.address,
-            asset=amm.assets[0], asset2=amm.assets[1],
+            asset=amm.assets[0],
+            asset2=amm.assets[1],
             bid_min=bid_amt,
         )
 

--- a/workload/src/workload/transactions/delegation.py
+++ b/workload/src/workload/transactions/delegation.py
@@ -3,8 +3,8 @@
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import DelegateSet
 from xrpl.models.transactions.delegate_set import (
-    GranularPermission,
     NON_DELEGABLE_TRANSACTIONS,
+    GranularPermission,
     Permission,
 )
 from xrpl.models.transactions.types import TransactionType
@@ -51,11 +51,13 @@ async def _delegate_set_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice([
-        "non_existent_authorize",
-        "empty_permissions",
-        "non_owner_submission",
-    ])
+    mutation = choice(
+        [
+            "non_existent_authorize",
+            "empty_permissions",
+            "non_owner_submission",
+        ]
+    )
     if mutation == "non_existent_authorize":
         src = choice(list(accounts.values()))
         all_perms = list(GranularPermission)
@@ -97,7 +99,6 @@ async def _delegate_set_faulty(
         await submit_tx("DelegateSet", txn, client, impostor.wallet)
 
 
-
 # ── Delegation helper for submit_tx ──────────────────────────────────
 
 # Names of non-delegable transaction types for fast lookup.
@@ -127,10 +128,9 @@ def maybe_delegate(
         return None, None
 
     candidates = [
-        d for d in delegates
-        if d.source == src_address
-        and tx_type in d.permissions
-        and d.delegate_address in accounts
+        d
+        for d in delegates
+        if d.source == src_address and tx_type in d.permissions and d.delegate_address in accounts
     ]
     if not candidates:
         return None, None

--- a/workload/src/workload/transactions/offers.py
+++ b/workload/src/workload/transactions/offers.py
@@ -17,6 +17,7 @@ from workload.models import AMM, TrustLine, UserAccount
 from workload.randoms import choice, randint, random
 from workload.submit import submit_tx
 from workload import params
+from workload.transactions.amm import _find_account_with_trust_lines
 
 # ── Helpers ─────────────────────────────────────────────────────────
 
@@ -73,35 +74,9 @@ def _find_account_for_amm(
     trust_lines: list[TrustLine],
     amm: AMM,
 ) -> UserAccount | None:
-    """Find an account that has trust lines for the AMM's IOU assets.
-
-    For XRP/IOU pools the account just needs the IOU trust line.
-    For IOU/IOU pools the account needs both trust lines.
-    """
-    needed_ious: list[IssuedCurrency] = []
-    for asset in amm.assets:
-        if not isinstance(asset, xrpl.models.XRP):
-            needed_ious.append(asset)
-
-    if not needed_ious:
-        # XRP/XRP pool (unusual) — any account works
-        return choice(list(accounts.values()))
-
-    # Build set of accounts that have all needed trust lines
-    tl_by_account: dict[str, set[tuple[str, str]]] = {}
-    for tl in trust_lines:
-        key = (tl.currency, tl.account_b)  # (currency, issuer)
-        tl_by_account.setdefault(tl.account_a, set()).add(key)
-
-    eligible = []
-    for addr, acct in accounts.items():
-        acct_tls = tl_by_account.get(addr, set())
-        if all((iou.currency, iou.issuer) in acct_tls for iou in needed_ious):
-            eligible.append(acct)
-
-    if not eligible:
-        return None
-    return choice(eligible)
+    """Find an account that has trust lines for the AMM's IOU assets."""
+    needed_ious = [a for a in amm.assets if not isinstance(a, xrpl.models.XRP)]
+    return _find_account_with_trust_lines(accounts, trust_lines, needed_ious)
 
 
 # ── OfferCreate ─────────────────────────────────────────────────────
@@ -138,7 +113,6 @@ async def _offer_create_valid(
         return
     taker_gets, taker_pays = pair
     flag = _random_flag()
-
     txn = OfferCreate(
         account=src.address,
         taker_gets=taker_gets,

--- a/workload/src/workload/transactions/offers.py
+++ b/workload/src/workload/transactions/offers.py
@@ -18,9 +18,6 @@ from workload.randoms import choice, randint, random
 from workload.submit import submit_tx
 from workload import params
 
-
-
-
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
@@ -141,7 +138,6 @@ async def _offer_create_valid(
         return
     taker_gets, taker_pays = pair
     flag = _random_flag()
-
 
     txn = OfferCreate(
         account=src.address,

--- a/workload/src/workload/transactions/offers.py
+++ b/workload/src/workload/transactions/offers.py
@@ -1,0 +1,293 @@
+"""OfferCreate / OfferCancel workload handlers.
+
+Creates DEX offers that trade through AMM pools, and cancels existing offers.
+"""
+
+from __future__ import annotations
+
+from xrpl.asyncio.clients import AsyncJsonRpcClient
+from xrpl.models import IssuedCurrencyAmount as IOUAmount
+from xrpl.models.currencies import IssuedCurrency
+from xrpl.models.transactions import OfferCreate, OfferCancel
+from xrpl.models.transactions.offer_create import OfferCreateFlag
+
+import xrpl.models
+
+from workload.models import AMM, TrustLine, UserAccount
+from workload.randoms import choice, randint, random
+from workload.submit import submit_tx
+from workload import params
+
+
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _fake_iou() -> IssuedCurrency:
+    return IssuedCurrency(currency=params.currency_code(), issuer=params.fake_account())
+
+
+def _random_flag() -> int:
+    """Pick a random OfferCreate flag or no flag."""
+    flags = [0, OfferCreateFlag.TF_PASSIVE, OfferCreateFlag.TF_SELL,
+             OfferCreateFlag.TF_IMMEDIATE_OR_CANCEL, OfferCreateFlag.TF_FILL_OR_KILL]
+    return choice(flags)
+
+
+def _iou_amount(asset: IssuedCurrency, value: str) -> IOUAmount:
+    return IOUAmount(currency=asset.currency, issuer=asset.issuer, value=value)
+
+
+def _make_offer_amounts(
+    amm: AMM,
+) -> tuple[str | IOUAmount, str | IOUAmount] | None:
+    """Build taker_gets / taker_pays from an AMM's asset pair.
+
+    Randomly picks direction: buy asset1 with asset2, or vice versa.
+    Returns (taker_gets, taker_pays) or None if assets are insufficient.
+    """
+    if len(amm.assets) < 2:
+        return None
+    a1, a2 = amm.assets[0], amm.assets[1]
+
+    # Randomly pick direction
+    if random() < 0.5:
+        get_asset, pay_asset = a1, a2
+    else:
+        get_asset, pay_asset = a2, a1
+
+    # Build amounts — use small amounts to increase chance of filling
+    if isinstance(get_asset, xrpl.models.XRP):
+        taker_gets = str(randint(100_000, 10_000_000))  # 0.1-10 XRP in drops
+    else:
+        taker_gets = _iou_amount(get_asset, str(randint(1, 50)))
+
+    if isinstance(pay_asset, xrpl.models.XRP):
+        taker_pays = str(randint(100_000, 10_000_000))
+    else:
+        taker_pays = _iou_amount(pay_asset, str(randint(1, 50)))
+
+    return taker_gets, taker_pays
+
+
+def _find_account_for_amm(
+    accounts: dict[str, UserAccount],
+    trust_lines: list[TrustLine],
+    amm: AMM,
+) -> UserAccount | None:
+    """Find an account that has trust lines for the AMM's IOU assets.
+
+    For XRP/IOU pools the account just needs the IOU trust line.
+    For IOU/IOU pools the account needs both trust lines.
+    """
+    needed_ious: list[IssuedCurrency] = []
+    for asset in amm.assets:
+        if not isinstance(asset, xrpl.models.XRP):
+            needed_ious.append(asset)
+
+    if not needed_ious:
+        # XRP/XRP pool (unusual) — any account works
+        return choice(list(accounts.values()))
+
+    # Build set of accounts that have all needed trust lines
+    tl_by_account: dict[str, set[tuple[str, str]]] = {}
+    for tl in trust_lines:
+        key = (tl.currency, tl.account_b)  # (currency, issuer)
+        tl_by_account.setdefault(tl.account_a, set()).add(key)
+
+    eligible = []
+    for addr, acct in accounts.items():
+        acct_tls = tl_by_account.get(addr, set())
+        if all((iou.currency, iou.issuer) in acct_tls for iou in needed_ious):
+            eligible.append(acct)
+
+    if not eligible:
+        return None
+    return choice(eligible)
+
+
+# ── OfferCreate ─────────────────────────────────────────────────────
+
+
+async def offer_create(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    offers: list[dict],
+    trust_lines: list[TrustLine],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _offer_create_faulty(accounts, amms, trust_lines, client)
+    return await _offer_create_valid(accounts, amms, trust_lines, client)
+
+
+async def _offer_create_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not amms:
+        return
+
+    amm = choice(amms)
+    src = _find_account_for_amm(accounts, trust_lines, amm)
+    if not src:
+        return
+
+    pair = _make_offer_amounts(amm)
+    if not pair:
+        return
+    taker_gets, taker_pays = pair
+    flag = _random_flag()
+
+
+    txn = OfferCreate(
+        account=src.address,
+        taker_gets=taker_gets,
+        taker_pays=taker_pays,
+        flags=flag,
+    )
+    await submit_tx("OfferCreate", txn, client, src.wallet)
+
+
+async def _offer_create_faulty(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+    client: AsyncJsonRpcClient,
+) -> None:
+    src = choice(list(accounts.values()))
+
+    mutation = choice([
+        "non_existent_asset", "same_asset_both", "zero_amount",
+        "negative_iou_amount", "crossed_offer",
+    ])
+    if mutation == "non_existent_asset":
+        # Offer with a fake IOU nobody has issued
+        fake = _fake_iou()
+        taker_gets = _iou_amount(fake, str(randint(1, 1_000)))
+        taker_pays = str(randint(1_000_000, 100_000_000))
+        txn = OfferCreate(
+            account=src.address,
+            taker_gets=taker_gets,
+            taker_pays=taker_pays,
+        )
+
+    elif mutation == "same_asset_both":
+        # Both sides are XRP (tecINSUF_RESERVE_OFFER or malformed)
+        txn = OfferCreate(
+            account=src.address,
+            taker_gets=str(randint(1_000_000, 100_000_000)),
+            taker_pays=str(randint(1_000_000, 100_000_000)),
+        )
+
+    elif mutation == "zero_amount":
+        # Zero taker_gets or taker_pays
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        a2 = amm.assets[1] if isinstance(amm.assets[0], xrpl.models.XRP) else amm.assets[0]
+        taker_gets = "0"
+        taker_pays = _iou_amount(a2, str(randint(1, 1_000)))
+        txn = OfferCreate(
+            account=src.address,
+            taker_gets=taker_gets,
+            taker_pays=taker_pays,
+        )
+
+    elif mutation == "negative_iou_amount":
+        # Negative IOU amount — passes xrpl-py, rejected by rippled
+        if not amms:
+            return
+        amm = choice(amms)
+        if len(amm.assets) < 2:
+            return
+        a2 = amm.assets[1] if isinstance(amm.assets[0], xrpl.models.XRP) else amm.assets[0]
+        taker_gets = str(randint(1_000_000, 100_000_000))
+        taker_pays = _iou_amount(a2, "-1")
+        txn = OfferCreate(
+            account=src.address,
+            taker_gets=taker_gets,
+            taker_pays=taker_pays,
+        )
+
+    else:  # crossed_offer
+        # Create an offer that crosses itself (same account, opposite direction)
+        if not amms:
+            return
+        amm = choice(amms)
+        pair = _make_offer_amounts(amm)
+        if not pair:
+            return
+        taker_gets, taker_pays = pair
+        # Swap to create a self-crossing offer
+        txn = OfferCreate(
+            account=src.address,
+            taker_gets=taker_pays,
+            taker_pays=taker_gets,
+        )
+
+    await submit_tx("OfferCreate", txn, client, src.wallet)
+
+
+# ── OfferCancel ─────────────────────────────────────────────────────
+
+
+async def offer_cancel(
+    accounts: dict[str, UserAccount],
+    offers: list[dict],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _offer_cancel_faulty(accounts, client)
+    return await _offer_cancel_valid(accounts, offers, client)
+
+
+async def _offer_cancel_valid(
+    accounts: dict[str, UserAccount],
+    offers: list[dict],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not offers:
+        return
+    offer = choice(offers)
+    acct = accounts.get(offer["account"])
+    if not acct:
+        return
+
+    txn = OfferCancel(
+        account=acct.address,
+        offer_sequence=offer["sequence"],
+    )
+    await submit_tx("OfferCancel", txn, client, acct.wallet)
+
+
+async def _offer_cancel_faulty(
+    accounts: dict[str, UserAccount],
+    client: AsyncJsonRpcClient,
+) -> None:
+    src = choice(list(accounts.values()))
+
+    mutation = choice([
+        "non_existent_sequence", "cancel_others_offer",
+    ])
+
+    if mutation == "non_existent_sequence":
+        # Cancel an offer that doesn't exist
+        txn = OfferCancel(
+            account=src.address,
+            offer_sequence=randint(900_000, 999_999),
+        )
+
+    else:  # cancel_others_offer
+        # Try to cancel someone else's offer (wrong account)
+        txn = OfferCancel(
+            account=src.address,
+            offer_sequence=randint(1, 100),
+        )
+
+    await submit_tx("OfferCancel", txn, client, src.wallet)

--- a/workload/src/workload/transactions/offers.py
+++ b/workload/src/workload/transactions/offers.py
@@ -5,18 +5,17 @@ Creates DEX offers that trade through AMM pools, and cancels existing offers.
 
 from __future__ import annotations
 
+import xrpl.models
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models import IssuedCurrencyAmount as IOUAmount
 from xrpl.models.currencies import IssuedCurrency
-from xrpl.models.transactions import OfferCreate, OfferCancel
+from xrpl.models.transactions import OfferCancel, OfferCreate
 from xrpl.models.transactions.offer_create import OfferCreateFlag
 
-import xrpl.models
-
-from workload.models import AMM, TrustLine, UserAccount
-from workload.randoms import choice, randint, random
-from workload.submit import submit_tx
 from workload import params
+from workload.models import AMM, TrustLine, UserAccount
+from workload.randoms import choice, randint, random, sample
+from workload.submit import submit_tx
 from workload.transactions.amm import _find_account_with_trust_lines
 
 # ── Helpers ─────────────────────────────────────────────────────────
@@ -27,10 +26,25 @@ def _fake_iou() -> IssuedCurrency:
 
 
 def _random_flag() -> int:
-    """Pick a random OfferCreate flag or no flag."""
-    flags = [0, OfferCreateFlag.TF_PASSIVE, OfferCreateFlag.TF_SELL,
-             OfferCreateFlag.TF_IMMEDIATE_OR_CANCEL, OfferCreateFlag.TF_FILL_OR_KILL]
-    return choice(flags)
+    """Pick a random combination of OfferCreate flags (or no flags).
+
+    XRPL allows combining flags like tfPassive | tfSell. We sample a random
+    subset and OR them together.
+    """
+    all_flags = [
+        OfferCreateFlag.TF_PASSIVE,
+        OfferCreateFlag.TF_SELL,
+        OfferCreateFlag.TF_IMMEDIATE_OR_CANCEL,
+        OfferCreateFlag.TF_FILL_OR_KILL,
+    ]
+    count = choice(range(len(all_flags) + 1))  # 0..4 flags
+    if count == 0:
+        return 0
+    picked = sample(all_flags, count)
+    result = 0
+    for f in picked:
+        result |= f
+    return result
 
 
 def _iou_amount(asset: IssuedCurrency, value: str) -> IOUAmount:
@@ -85,7 +99,6 @@ def _find_account_for_amm(
 async def offer_create(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
-    offers: list[dict],
     trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
@@ -128,12 +141,19 @@ async def _offer_create_faulty(
     trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
+    if not accounts:
+        return
     src = choice(list(accounts.values()))
 
-    mutation = choice([
-        "non_existent_asset", "same_asset_both", "zero_amount",
-        "negative_iou_amount", "crossed_offer",
-    ])
+    mutation = choice(
+        [
+            "non_existent_asset",
+            "same_asset_both",
+            "zero_amount",
+            "negative_iou_amount",
+            "crossed_offer",
+        ]
+    )
     if mutation == "non_existent_asset":
         # Offer with a fake IOU nobody has issued
         fake = _fake_iou()
@@ -240,11 +260,16 @@ async def _offer_cancel_faulty(
     accounts: dict[str, UserAccount],
     client: AsyncJsonRpcClient,
 ) -> None:
+    if not accounts:
+        return
     src = choice(list(accounts.values()))
 
-    mutation = choice([
-        "non_existent_sequence", "cancel_others_offer",
-    ])
+    mutation = choice(
+        [
+            "non_existent_sequence",
+            "cancel_others_offer",
+        ]
+    )
 
     if mutation == "non_existent_sequence":
         # Cancel an offer that doesn't exist
@@ -254,7 +279,10 @@ async def _offer_cancel_faulty(
         )
 
     else:  # cancel_others_offer
-        # Try to cancel someone else's offer (wrong account)
+        # Submit from src but use a sequence that likely belongs to another
+        # account. Since OfferCancel only cancels the submitter's own offers,
+        # this effectively becomes a non-existent sequence for src — exercising
+        # the "wrong owner" path from the submitter's perspective.
         txn = OfferCancel(
             account=src.address,
             offer_sequence=randint(1, 100),


### PR DESCRIPTION
- Valid and faulty workloads for `Offer` and `AMM` transaction types.
- Added `_find_account_with_trust_lines` shared helper used by both AMM and Offer handlers.
- All paths integrate with delegation transparently through `submit_tx`.
