### PR TITLE
Applying ticket sequence to eligible transactions

### DIFF
--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -17,11 +17,11 @@ from xrpl.wallet import Wallet
 
 from workload import logger
 from workload.assertions import register_assertions
-from workload.transactions.tickets import check_ticket_coverage
 from workload.check_xrpld_sync_state import is_xrpld_synced
 from workload.config import conf_file, config_file
 from workload.models import UserAccount
 from workload.transactions import REGISTRY
+from workload.transactions.tickets import check_ticket_coverage
 
 
 class Workload:
@@ -83,6 +83,7 @@ class Workload:
 
         # Wire delegation state so submit_tx can transparently delegate.
         from workload.submit import configure as configure_submit
+
         configure_submit(self.delegates, self.accounts)
 
         logger.info("Antithesis SDK handler: %s", type(_HANDLER).__name__)
@@ -161,6 +162,7 @@ get_workload = None
 
 def create_app(workload: Workload) -> FastAPI:
     import asyncio
+    import contextlib
     from contextlib import asynccontextmanager
 
     from workload.ws_listener import start_ws_listener
@@ -186,10 +188,8 @@ def create_app(workload: Workload) -> FastAPI:
         yield  # app runs here, shutdown after yield
 
         ws_task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await ws_task
-        except asyncio.CancelledError:
-            pass
 
     app = FastAPI(lifespan=lifespan)
 

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -17,6 +17,7 @@ from xrpl.wallet import Wallet
 
 from workload import logger
 from workload.assertions import register_assertions
+from workload.transactions.tickets import check_ticket_coverage
 from workload.check_xrpld_sync_state import is_xrpld_synced
 from workload.config import conf_file, config_file
 from workload.models import UserAccount
@@ -89,6 +90,7 @@ class Workload:
         always(True, "workload::sdk_works", {"message": "SDK canary assertion"})
 
         register_assertions()
+        check_ticket_coverage()
 
         logger.info("Workload initialized after %ss", int(time.time() - self.start_time))
 
@@ -167,7 +169,7 @@ def create_app(workload: Workload) -> FastAPI:
     async def lifespan(app: FastAPI):
         from workload.setup import run_setup
 
-        asyncio.create_task(start_ws_listener(workload, workload.xrpld_ws))
+        ws_task = asyncio.create_task(start_ws_listener(workload, workload.xrpld_ws))
         await asyncio.sleep(1)  # let WS listener connect before setup submits
 
         try:
@@ -182,6 +184,12 @@ def create_app(workload: Workload) -> FastAPI:
 
         lifecycle.setup_complete(details={"message": "Setup complete, faults may begin"})
         yield  # app runs here, shutdown after yield
+
+        ws_task.cancel()
+        try:
+            await ws_task
+        except asyncio.CancelledError:
+            pass
 
     app = FastAPI(lifespan=lifespan)
 

--- a/workload/src/workload/transactions/tickets.py
+++ b/workload/src/workload/transactions/tickets.py
@@ -1,13 +1,145 @@
 """Ticket transaction generators for the antithesis workload."""
 
+from collections.abc import Callable
+
 import xrpl.models
 from xrpl.asyncio.clients import AsyncJsonRpcClient
-from xrpl.models.transactions import Payment
+from xrpl.models.amounts import IssuedCurrencyAmount
+from xrpl.models.transactions import (
+    AccountSet,
+    CredentialCreate,
+    MPTokenIssuanceCreate,
+    NFTokenMint,
+    Payment,
+    PermissionedDomainSet,
+    TrustSet,
+)
+from xrpl.models.transactions.deposit_preauth import Credential as XRPLCredential
+from xrpl.models.transactions.mptoken_issuance_create import MPTokenIssuanceCreateFlag
+from xrpl.models.transactions.nftoken_mint import NFTokenMintFlag
+from xrpl.models.transactions.transaction import Memo
 
 from workload import params
+from workload.assertions import tx_submitted
 from workload.models import UserAccount
 from workload.randoms import choice
 from workload.submit import submit_tx
+
+# ── Ticket-eligible transaction builders ─────────────────────────────
+# Each builder takes (dst_addr, common) and returns a Transaction.
+# ``common`` already contains account, sequence=0, ticket_sequence=N.
+# Only types that need NO pre-existing object IDs belong here.
+# To add a new type: add one entry to this dict.
+
+_TicketBuilder = Callable[[str, dict], xrpl.models.Transaction]
+
+_TICKET_BUILDERS: dict[str, _TicketBuilder] = {
+    "Payment": lambda dst, c: Payment(
+        destination=dst,
+        amount=params.payment_amount(),
+        **c,
+    ),
+    # dst as credential issuer is intentional — exercises the domain with an
+    # arbitrary issuer so ticket-derived keylets get the coverage we need.
+    "PermissionedDomainSet": lambda dst, c: PermissionedDomainSet(
+        accepted_credentials=[
+            XRPLCredential(issuer=dst, credential_type=params.credential_type()),
+        ],
+        **c,
+    ),
+    "NFTokenMint": lambda dst, c: NFTokenMint(
+        nftoken_taxon=params.nft_taxon(),
+        transfer_fee=params.nft_transfer_fee(),
+        flags=NFTokenMintFlag.TF_TRANSFERABLE,
+        memos=[Memo(memo_data=params.nft_memo().encode("utf-8").hex())],
+        **c,
+    ),
+    "CredentialCreate": lambda dst, c: CredentialCreate(
+        subject=dst,
+        credential_type=params.credential_type(),
+        **c,
+    ),
+    "MPTokenIssuanceCreate": lambda dst, c: MPTokenIssuanceCreate(
+        maximum_amount=params.mpt_maximum_amount(),
+        mptoken_metadata=params.mpt_metadata(),
+        flags=MPTokenIssuanceCreateFlag.TF_MPT_CAN_LOCK,
+        **c,
+    ),
+    "AccountSet": lambda dst, c: AccountSet(**c),
+    "TrustSet": lambda dst, c: TrustSet(
+        limit_amount=IssuedCurrencyAmount(
+            currency=params.currency_code(),
+            issuer=dst,
+            value=params.trustline_limit(),
+        ),
+        **c,
+    ),
+}
+
+# Types explicitly excluded from ticket use.  Reasons:
+#   "objects"  — requires pre-existing object IDs (vault_id, nft, offer, etc.)
+#   "circular" — tickets creating/using tickets
+#   "cosign"   — requires multi-party signing
+#   "batch"    — outer batch manages inner sequences
+# Adding a new REGISTRY type without a builder or exclusion triggers a
+# startup warning so new types can't silently skip ticket coverage.
+_TICKET_EXCLUDED: set[str] = {
+    # circular — tickets creating/using tickets
+    "TicketCreate",
+    "TicketUse",
+    # batch — outer batch manages inner sequences
+    "Batch",
+    # cosign — requires multi-party signing
+    "LoanSet",
+    # objects — requires pre-existing object IDs
+    "NFTokenBurn",
+    "NFTokenModify",
+    "NFTokenCreateOffer",
+    "NFTokenCancelOffer",
+    "NFTokenAcceptOffer",
+    "MPTokenAuthorize",
+    "MPTokenIssuanceSet",
+    "MPTokenIssuanceDestroy",
+    "CredentialAccept",
+    "CredentialDelete",
+    "VaultCreate",
+    "VaultDeposit",
+    "VaultWithdraw",
+    "VaultSet",
+    "VaultDelete",
+    "VaultClawback",
+    "PermissionedDomainDelete",
+    "DelegateSet",
+    "LoanBrokerSet",
+    "LoanBrokerDelete",
+    "LoanBrokerCoverDeposit",
+    "LoanBrokerCoverWithdraw",
+    "LoanDelete",
+    "LoanManage",
+    "LoanPay",
+}
+
+
+def check_ticket_coverage() -> None:
+    """Assert at startup that every REGISTRY type is covered.
+
+    Called during app init.  Compares REGISTRY against _TICKET_BUILDERS
+    and _TICKET_EXCLUDED so new types can't silently skip ticket coverage.
+    Missing types fire an ``unreachable`` assertion that surfaces in
+    Antithesis triage.
+    """
+    from antithesis.assertions import unreachable
+
+    from workload.transactions import TX_TYPES
+
+    for name in TX_TYPES:
+        if name in _TICKET_BUILDERS or name in _TICKET_EXCLUDED:
+            continue
+        unreachable(
+            "workload::ticket_coverage_missing",
+            {"tx_type": name},
+        )
+
 
 # ── Create ───────────────────────────────────────────────────────────
 
@@ -58,16 +190,18 @@ async def _ticket_use_valid(accounts: dict[str, UserAccount], client: AsyncJsonR
     if not other_accounts:
         return
     dst = choice(other_accounts)
-    payment_txn = Payment(
-        account=src.address,
-        destination=dst,
-        amount=params.payment_amount(),
-        sequence=0,
-        ticket_sequence=ticket_sequence,
-    )
+
+    # Randomly pick a ticket-eligible transaction type
+    tx_type = choice(list(_TICKET_BUILDERS))
+    common = {"account": src.address, "sequence": 0, "ticket_sequence": ticket_sequence}
+    txn = _TICKET_BUILDERS[tx_type](dst, common)
+
     # Remove ticket optimistically to avoid reuse by concurrent calls
     src.tickets.discard(ticket_sequence)
-    await submit_tx("TicketUse", payment_txn, client, src.wallet)
+    # Hit the TicketUse reachability assertion separately — submit_tx uses
+    # the inner type so success/failure track the real TransactionType.
+    tx_submitted("TicketUse", txn)
+    await submit_tx(tx_type, txn, client, src.wallet)
 
 
 async def _ticket_use_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:


### PR DESCRIPTION
- Added `TicketCreate` and `TicketUse` handlers with a registry of 7 ticket-eligible transaction types (Payment, PermissionedDomainSet, NFTokenMint, CredentialCreate, MPTokenIssuanceCreate, AccountSet, TrustSet)
- Added `_TICKET_EXCLUDED` set (29 types) and a startup coverage check using unreachable() so new registry types can't silently skip ticket coverage.
- `_on_ticket_create` state updater tracks ticket sequences per account; TicketUse consumes and discards them.
- `submit_tx` receives the actual inner transaction type for correct assertion counting.
- WS listener task properly held and cancelled on shutdown.