### PR TITLE
Surface submit-time engine result and assert no rippled-internal errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Always use `submit_tx()` from `submit.py` — it wires `tx_submitted()` assertio
 Each `_faulty` handler picks ONE random mutation via `choice()`, constructs a deliberately invalid transaction, and submits via `submit_tx`. Must never raise — precondition checks same as `_valid`. Common mutations: `params.fake_id()` (nonexistent object), non-owner submission, zero/negative amounts, mismatched asset types, overdraw (`balance + randint(...)`). Keep overdraw/state-aware mutations in `_faulty` only — `_valid` handlers must use amounts within tracked balances.
 
 ### LoanSet co-signing
-`LoanSet` requires dual signing (borrower + broker). Uses `autofill_and_sign` → `sign_loan_set_by_counterparty` → `xrpl_submit` directly (not `submit_tx`). Calls `tx_submitted("LoanSet", txn)` manually before submit. See `lending.py:_loan_set_valid`.
+`LoanSet` requires dual signing (borrower + broker). Uses `autofill_and_sign` → `sign_loan_set_by_counterparty` → `xrpl_submit` directly (not `submit_tx`). Calls `tx_submitted("LoanSet", txn, response.result)` after submit so the submit-time tef* internal-error assertion fires on the engine result. See `lending.py:_loan_set_valid`. Setup-phase paths that submit directly (`setup.py` LoanSet co-sign and `_probe_node`) call `assert_no_internal_error_submit(name, resp.result)` instead — they emit their own `setup_*` events rather than the runtime `submitted` event.
 
 ### XRPL specifications
 Transaction format docs are at `xrpl.org/docs/references/protocol/transactions/types/<name>`. Authoritative XLS specifications (especially for newer features like vaults and lending) live in `github.com/XRPLF/XRPL-Standards` under `XLS-NNNN-<name>/`.

--- a/workload/src/workload/assertions.py
+++ b/workload/src/workload/assertions.py
@@ -16,6 +16,17 @@ _LOC_FILE = "workload/assertions.py"
 _LOC_CLASS = ""
 _LOC_COL = 0
 
+# Engine results that indicate a rippled internal error (exception caught,
+# invariant violated, etc.). Surfaced from BOTH the immediate /submit response
+# and the validated WS stream — though tef* never reaches validation, so the
+# submit-time check is what actually catches these in practice.
+_RIPPLED_INTERNAL_ERRORS = (
+    "tefEXCEPTION",
+    "tefINTERNAL",
+    "tefINVARIANT_FAILED",
+    "tefFAILURE",
+)
+
 # XRPL fields → normalized event keys. Only object identifiers needed for tracking.
 _OBJECT_ID_FIELDS: dict[str, str] = {
     "Destination": "destination",
@@ -86,8 +97,9 @@ def register_assertions() -> None:
         "workload::always : no_internal_rippled_error", "always", "Always", must_hit=True
     )
     _emit_catalog_entry(
-        "workload::always : no_temDISABLED", "always", "Always", must_hit=True
+        "workload::always : no_internal_rippled_error_submit", "always", "Always", must_hit=True
     )
+    _emit_catalog_entry("workload::always : no_temDISABLED", "always", "Always", must_hit=True)
     for setup_key in [
         "gateways",
         "trust_lines",
@@ -111,8 +123,46 @@ def register_assertions() -> None:
         )
 
 
-def tx_submitted(name: str, txn: object = None) -> None:
-    """Report that a transaction was created and submitted to the network."""
+def assert_no_internal_error_submit(name: str, result: dict) -> None:
+    """Fire the no_internal_rippled_error_submit always-assertion for a submit result.
+
+    Use from any path that submits directly via xrpl-py (bypassing ``submit_tx``)
+    — e.g. setup-phase LoanSet co-signing and the node probe. Submit-time is
+    where tef* internal errors must be caught: they never enter a closed ledger
+    and so never reach the validated WS stream that ``tx_result`` consumes.
+    """
+    engine_result = result.get("engine_result", "") or ""
+    if not engine_result:
+        return
+    tx_hash = result.get("tx_json", {}).get("hash", "") or result.get("hash", "")
+    assert_raw(
+        condition=engine_result not in _RIPPLED_INTERNAL_ERRORS,
+        message="workload::always : no_internal_rippled_error_submit",
+        details={
+            "engine_result": engine_result,
+            "tx_type": name,
+            "hash": tx_hash,
+        },
+        loc_filename=_LOC_FILE,
+        loc_function="assert_no_internal_error_submit",
+        loc_class=_LOC_CLASS,
+        loc_begin_line=0,
+        loc_begin_column=_LOC_COL,
+        hit=True,
+        must_hit=True,
+        assert_type="always",
+        display_type="Always",
+        assert_id="workload::always : no_internal_rippled_error_submit",
+    )
+
+
+def tx_submitted(name: str, txn: object = None, result: dict | None = None) -> None:
+    """Report that a transaction was submitted to the network.
+
+    ``result`` is the immediate /submit response dict. Passing it here
+    surfaces ``engine_result`` in the event details and triggers the
+    submit-time tef* internal-error always-assertion.
+    """
     details: dict[str, str] = {"tx_type": name}
     if txn is not None:
         try:
@@ -122,6 +172,16 @@ def tx_submitted(name: str, txn: object = None) -> None:
             details.update(_extract_object_ids(raw))
         except Exception:
             pass
+    if result is not None:
+        engine_result = result.get("engine_result", "") or ""
+        engine_result_message = result.get("engine_result_message", "") or ""
+        tx_hash = result.get("tx_json", {}).get("hash", "") or result.get("hash", "")
+        if engine_result:
+            details["engine_result"] = engine_result
+        if engine_result_message:
+            details["engine_result_message"] = engine_result_message
+        if tx_hash:
+            details["hash"] = tx_hash
     send_event(f"workload::submitted : {name}", details)
     assert_raw(
         condition=True,
@@ -138,6 +198,8 @@ def tx_submitted(name: str, txn: object = None) -> None:
         display_type="Reachable",
         assert_id=_seen_id(name),
     )
+    if result is not None:
+        assert_no_internal_error_submit(name, result)
 
 
 def tx_result(name: str, result: dict) -> None:
@@ -167,12 +229,6 @@ def tx_result(name: str, result: dict) -> None:
             break
     send_event(f"workload::result : {name}", details)
 
-    _RIPPLED_INTERNAL_ERRORS = (
-        "tefEXCEPTION",
-        "tefINTERNAL",
-        "tefINVARIANT_FAILED",
-        "tefFAILURE",
-    )
     assert_raw(
         condition=engine_result not in _RIPPLED_INTERNAL_ERRORS,
         message="workload::always : no_internal_rippled_error",

--- a/workload/src/workload/setup.py
+++ b/workload/src/workload/setup.py
@@ -58,6 +58,7 @@ from xrpl.transaction.counterparty_signer import sign_loan_set_by_counterparty
 from xrpl.wallet import Wallet
 
 from workload import params
+from workload.assertions import assert_no_internal_error_submit
 from workload.models import UserAccount
 from workload.sequence import SequenceTracker
 from workload.submit import submit_tx
@@ -172,6 +173,7 @@ async def _submit_loan(
     signed = await autofill_and_sign(txn, workload.client, borrower.wallet)
     cosigned = sign_loan_set_by_counterparty(broker_wallet, signed)
     resp = await xrpl_submit(cosigned.tx, workload.client)
+    assert_no_internal_error_submit("LoanSet", resp.result)
     engine = resp.result.get("engine_result", "")
     ok = engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ")
     if not ok:
@@ -206,6 +208,7 @@ async def _probe_node(workload: Workload) -> None:
             probe = AccountSet(account=workload.funding_wallet.address)
             signed = await autofill_and_sign(probe, workload.client, workload.funding_wallet)
             resp = await xrpl_submit(signed, workload.client)
+            assert_no_internal_error_submit("AccountSet", resp.result)
             engine = resp.result.get("engine_result", "")
             if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ"):
                 send_event(

--- a/workload/src/workload/submit.py
+++ b/workload/src/workload/submit.py
@@ -60,8 +60,12 @@ async def submit_tx(
     # Possibly delegate: lazy import to avoid circular dependency
     if _delegates:
         from workload.transactions.delegation import maybe_delegate
+
         delegate_addr, delegate_wallet = maybe_delegate(
-            name, txn.account, _delegates, _accounts,
+            name,
+            txn.account,
+            _delegates,
+            _accounts,
         )
         if delegate_addr is not None:
             txn = txn.__replace__(delegate=delegate_addr)
@@ -70,7 +74,5 @@ async def submit_tx(
     signed = await autofill_and_sign(txn, client, wallet)
     response = await submit(signed, client)
     result = response.result
-    tx_submitted(name, txn)
-    # TODO: re-enable as structured JSON log for tx sequence analysis
-    # {"tx_type": name, "engine_result": preliminary, "hash": tx_hash, "seq": seq}
+    tx_submitted(name, txn, result)
     return result

--- a/workload/src/workload/transactions/lending.py
+++ b/workload/src/workload/transactions/lending.py
@@ -377,10 +377,8 @@ async def _loan_set_valid(
     # LoanSet requires counterparty co-signing: borrower signs, then broker co-signs
     signed = await autofill_and_sign(txn, client, borrower.wallet)
     cosigned = sign_loan_set_by_counterparty(broker_wallet, signed)
-    tx_submitted("LoanSet", txn)
-    await xrpl_submit(cosigned.tx, client)
-    # TODO: re-enable as structured log for tx sequence analysis
-    # {"tx_type": "LoanSet", "engine_result": response.result.get("engine_result", "")}
+    response = await xrpl_submit(cosigned.tx, client)
+    tx_submitted("LoanSet", txn, response.result)
 
 
 async def _loan_set_faulty(


### PR DESCRIPTION
## Summary
- `tef*` internal errors (tefEXCEPTION, tefINTERNAL, tefINVARIANT_FAILED, tefFAILURE) never enter a closed ledger, so they never reach the validated WS stream that `tx_result` consumes. The existing `no_internal_rippled_error` always-assertion was effectively unreachable for those cases.
- Capture the `/submit` response in `submit_tx` and pipe it through `tx_submitted`, which now surfaces `engine_result`/`engine_result_message`/`hash` in the `submitted` event and fires a new `no_internal_rippled_error_submit` always-assertion.
- Extract `assert_no_internal_error_submit(name, result)` so setup paths that submit directly via `xrpl_submit` (LoanSet co-signing, node probe) are covered too.
- Update `CLAUDE.md` LoanSet/setup docs to reflect the new signature and the helper.

## Test plan
- [x] `scripts/check-imports`
- [x] `scripts/check-endpoints`
- [x] `ruff check` + `ruff format --check` on changed files
- [ ] Antithesis run confirms `workload::always : no_internal_rippled_error_submit` registers and fires only on tef* engine results