### PR TITLE
Add Oracle (OracleSet + OracleDelete) transaction workloads

### DIFF
--- a/scripts/check-endpoints
+++ b/scripts/check-endpoints
@@ -42,6 +42,8 @@ try:
         '/delegate/set/random',
         '/did/set/random',
         '/did/delete/random',
+        '/oracle/set/random',
+        '/oracle/delete/random',
         '/nft/modify/random',
         '/mpt/create/random',
         '/mpt/authorize/random',

--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -19,6 +19,7 @@ from workload.transactions.payment_channels import channel_create, channel_fund,
 from workload.transactions.set_regular_key import set_regular_key
 from workload.transactions.signer_list_set import signer_list_set
 from workload.transactions.did import did_set, did_delete
+from workload.transactions.oracle import oracle_set, oracle_delete
 from workload.transactions.mpt import mpt_create, mpt_authorize, mpt_issuance_set, mpt_destroy
 from workload.transactions.nft import nftoken_mint, nftoken_modify
 from workload.transactions.offers import offer_create, offer_cancel
@@ -33,6 +34,6 @@ from workload.sequence import SequenceTracker
 from workload.ws_listener import start_ws_listener
 from workload.setup import run_setup
 from workload.params import should_send_faulty, fake_account, fake_id
-from workload.models import UserAccount, Credential, Vault, PermissionedDomain, MPTokenIssuance, LoanBroker, Loan, Delegate, DID
+from workload.models import UserAccount, Credential, Vault, PermissionedDomain, MPTokenIssuance, LoanBroker, Loan, Delegate, DID, Oracle
 print('All imports OK')
 "

--- a/test_composer/all_transactions/parallel_driver_oracle_delete_random.sh
+++ b/test_composer/all_transactions/parallel_driver_oracle_delete_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/oracle/delete/random

--- a/test_composer/all_transactions/parallel_driver_oracle_set_random.sh
+++ b/test_composer/all_transactions/parallel_driver_oracle_set_random.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://workload:8000/oracle/set/random

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -40,6 +40,7 @@ class Workload:
         self.mpt_issuances = []
         self.delegates = []
         self.dids = []
+        self.oracles = []
         self.loan_brokers = []
         self.loans = []
         self.escrows = []

--- a/workload/src/workload/assertions.py
+++ b/workload/src/workload/assertions.py
@@ -52,6 +52,8 @@ _NO_SUCCESS_TYPES = {"AccountDelete", "AMMDelete"}
 _META_EXPECTATIONS: dict[str, tuple[str, ...]] = {
     "DIDSet": ("Created", "Modified", "DID"),
     "DIDDelete": ("Deleted", "DID"),
+    "OracleSet": ("Created", "Modified", "Oracle"),
+    "OracleDelete": ("Deleted", "Oracle"),
 }
 
 # XRPL fields → normalized event keys. Only object identifiers needed for tracking.
@@ -65,6 +67,7 @@ _OBJECT_ID_FIELDS: dict[str, str] = {
     "Subject": "subject",
     "Issuer": "issuer",
     "CredentialType": "credential_type",
+    "OracleDocumentID": "oracle_document_id",
 }
 
 

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -173,3 +173,13 @@ class PaymentChannel:
     destination: str
     amount: str  # total XRP drops allocated
     settle_delay: int
+
+
+@dataclass
+class Oracle:
+    """An active price oracle on the ledger (XLS-47)."""
+
+    account: str
+    document_id: int
+    provider: str
+    asset_class: str

--- a/workload/src/workload/params.py
+++ b/workload/src/workload/params.py
@@ -380,3 +380,65 @@ def did_hex_field() -> str:
         n = randint(101, 128)  # near the 256-hex-char / 128-byte limit
     # n is number of BYTES; each byte = 2 hex chars → always even length
     return "".join(choice(_HEX_CHARS) for _ in range(n * 2))
+
+
+# ── Price Oracle (XLS-47) ─────────────────────────────────────────────
+
+
+def oracle_document_id() -> int:
+    """Random OracleDocumentID (uint32)."""
+    return randint(0, 2**32 - 1)
+
+
+def oracle_provider() -> str:
+    """Random Provider string (up to 256 bytes)."""
+    providers = [
+        "chainlink",
+        "band_protocol",
+        "pyth_network",
+        "switchboard",
+        "dia_data",
+        "api3",
+        "redstone",
+        "uma_protocol",
+    ]
+    return choice(providers) + "_" + str(randint(0, 999))
+
+
+def oracle_asset_class() -> str:
+    """Random AssetClass string (up to 16 bytes)."""
+    return choice(["currency", "commodity", "stock", "crypto"])
+
+
+def oracle_base_asset() -> str:
+    """Random base asset for a PriceData entry."""
+    return choice(["XRP", "USD", "EUR", "BTC", "ETH", "JPY", "GBP"])
+
+
+def oracle_quote_asset() -> str:
+    """Random quote asset for a PriceData entry."""
+    return choice(["USD", "EUR", "XRP", "BTC", "ETH", "JPY", "GBP"])
+
+
+def oracle_asset_price() -> int:
+    """Random AssetPrice (uint64 but keep reasonable)."""
+    return randint(1, 10_000_000)
+
+
+def oracle_scale() -> int:
+    """Random Scale (0-10)."""
+    return randint(0, 10)
+
+
+def oracle_price_data_count() -> int:
+    """Number of PriceData entries (1-5, spec allows up to 10)."""
+    return randint(1, 5)
+
+
+def oracle_last_update_time() -> int:
+    """Seconds since XRPL epoch (Jan 1 2000). Use current-ish time."""
+    import time
+
+    # XRPL epoch offset from Unix epoch
+    xrpl_epoch = 946684800
+    return int(time.time()) - xrpl_epoch

--- a/workload/src/workload/params.py
+++ b/workload/src/workload/params.py
@@ -391,7 +391,7 @@ def oracle_document_id() -> int:
 
 
 def oracle_provider() -> str:
-    """Random Provider string (up to 256 bytes)."""
+    """Random Provider string, hex-encoded (up to 256 hex chars)."""
     providers = [
         "chainlink",
         "band_protocol",
@@ -402,12 +402,14 @@ def oracle_provider() -> str:
         "redstone",
         "uma_protocol",
     ]
-    return choice(providers) + "_" + str(randint(0, 999))
+    raw = choice(providers) + "_" + str(randint(0, 999))
+    return raw.encode().hex().upper()
 
 
 def oracle_asset_class() -> str:
-    """Random AssetClass string (up to 16 bytes)."""
-    return choice(["currency", "commodity", "stock", "crypto"])
+    """Random AssetClass string, hex-encoded (up to 16 hex chars)."""
+    raw = choice(["currency", "commodity", "stock", "crypto"])
+    return raw.encode().hex().upper()
 
 
 def oracle_base_asset() -> str:

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -36,6 +36,7 @@ from workload.models import (
     LoanBroker,
     MPTokenIssuance,
     NFTOffer,
+    Oracle,
     PaymentChannel,
     PermissionedDomain,
     TrustLine,
@@ -83,6 +84,7 @@ from workload.transactions.nft import (
     nftoken_modify,
 )
 from workload.transactions.offers import offer_cancel, offer_create
+from workload.transactions.oracle import oracle_delete, oracle_set
 from workload.transactions.payment_channels import (
     channel_claim,
     channel_create,
@@ -482,6 +484,39 @@ def _on_did_delete(w: Workload, tx: dict, meta: dict) -> None:
     """Remove DID from w.dids."""
     account = tx.get("Account", "")
     w.dids[:] = [d for d in w.dids if d.account != account]
+
+
+def _on_oracle_set(w: Workload, tx: dict, meta: dict) -> None:
+    account = tx.get("Account", "")
+    doc_id = tx.get("OracleDocumentID")
+    provider = tx.get("Provider", "")
+    asset_class = tx.get("AssetClass", "")
+    if doc_id is None:
+        return
+    # Idempotent: update if exists, else create
+    for o in w.oracles:
+        if o.account == account and o.document_id == doc_id:
+            if provider:
+                o.provider = provider
+            if asset_class:
+                o.asset_class = asset_class
+            return
+    w.oracles.append(
+        Oracle(
+            account=account,
+            document_id=doc_id,
+            provider=provider,
+            asset_class=asset_class,
+        )
+    )
+
+
+def _on_oracle_delete(w: Workload, tx: dict, meta: dict) -> None:
+    account = tx.get("Account", "")
+    doc_id = tx.get("OracleDocumentID")
+    if doc_id is None:
+        return
+    w.oracles[:] = [o for o in w.oracles if not (o.account == account and o.document_id == doc_id)]
 
 
 def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
@@ -935,6 +970,20 @@ REGISTRY = [
         did_delete,
         lambda w: (w.accounts, w.dids, w.client),
         _on_did_delete,
+    ),
+    (
+        "OracleSet",
+        "/oracle/set/random",
+        oracle_set,
+        lambda w: (w.accounts, w.oracles, w.client),
+        _on_oracle_set,
+    ),
+    (
+        "OracleDelete",
+        "/oracle/delete/random",
+        oracle_delete,
+        lambda w: (w.accounts, w.oracles, w.client),
+        _on_oracle_delete,
     ),
     (
         "LoanBrokerSet",

--- a/workload/src/workload/transactions/did.py
+++ b/workload/src/workload/transactions/did.py
@@ -49,13 +49,11 @@ async def _did_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcC
 async def _did_set_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
     if not accounts:
         return
-    mutation = choice(
-        [
-            "non_owner_submission",
-            "invalid_flags",
-            "single_empty_field",
-        ]
-    )
+    mutation = choice([
+        "non_owner_submission",
+        "invalid_flags",
+        "single_empty_field",
+    ])
     if mutation == "non_owner_submission":
         accounts_list = list(accounts.values())
         if len(accounts_list) < 2:
@@ -103,13 +101,11 @@ async def _did_delete_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice(
-        [
-            "delete_no_did",
-            "non_owner_submission",
-            "invalid_flags",
-        ]
-    )
+    mutation = choice([
+        "delete_no_did",
+        "non_owner_submission",
+        "invalid_flags",
+    ])
     accounts_list = list(accounts.values())
     if mutation == "delete_no_did":
         did_owners = {d.account for d in dids}

--- a/workload/src/workload/transactions/did.py
+++ b/workload/src/workload/transactions/did.py
@@ -49,11 +49,13 @@ async def _did_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcC
 async def _did_set_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
     if not accounts:
         return
-    mutation = choice([
-        "non_owner_submission",
-        "invalid_flags",
-        "single_empty_field",
-    ])
+    mutation = choice(
+        [
+            "non_owner_submission",
+            "invalid_flags",
+            "single_empty_field",
+        ]
+    )
     if mutation == "non_owner_submission":
         accounts_list = list(accounts.values())
         if len(accounts_list) < 2:
@@ -101,11 +103,13 @@ async def _did_delete_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice([
-        "delete_no_did",
-        "non_owner_submission",
-        "invalid_flags",
-    ])
+    mutation = choice(
+        [
+            "delete_no_did",
+            "non_owner_submission",
+            "invalid_flags",
+        ]
+    )
     accounts_list = list(accounts.values())
     if mutation == "delete_no_did":
         did_owners = {d.account for d in dids}

--- a/workload/src/workload/transactions/oracle.py
+++ b/workload/src/workload/transactions/oracle.py
@@ -1,0 +1,252 @@
+"""Price Oracle transaction generators for the antithesis workload (XLS-47)."""
+
+from xrpl.asyncio.clients import AsyncJsonRpcClient
+from xrpl.models.transactions import OracleDelete, OracleSet
+from xrpl.models.transactions.oracle_set import PriceData
+
+from workload import params
+from workload.models import Oracle, UserAccount
+from workload.randoms import choice, randint, sample
+from workload.submit import submit_tx
+
+
+def _random_price_data_series() -> list[PriceData]:
+    """Generate a random list of 1-5 PriceData entries with unique pairs."""
+    count = params.oracle_price_data_count()
+    seen_pairs: set[tuple[str, str]] = set()
+    entries: list[PriceData] = []
+    for _ in range(count):
+        base = params.oracle_base_asset()
+        quote = params.oracle_quote_asset()
+        # Ensure unique base/quote pairs within the series
+        if (base, quote) in seen_pairs:
+            continue
+        seen_pairs.add((base, quote))
+        entries.append(
+            PriceData(
+                base_asset=base,
+                quote_asset=quote,
+                asset_price=params.oracle_asset_price(),
+                scale=params.oracle_scale(),
+            )
+        )
+    # Must have at least one entry
+    if not entries:
+        entries.append(
+            PriceData(
+                base_asset=params.oracle_base_asset(),
+                quote_asset=params.oracle_quote_asset(),
+                asset_price=params.oracle_asset_price(),
+                scale=params.oracle_scale(),
+            )
+        )
+    return entries
+
+
+# ── OracleSet ────────────────────────────────────────────────────────
+
+
+async def oracle_set(
+    accounts: dict[str, UserAccount],
+    oracles: list[Oracle],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _oracle_set_faulty(accounts, oracles, client)
+    return await _oracle_set_valid(accounts, oracles, client)
+
+
+async def _oracle_set_valid(
+    accounts: dict[str, UserAccount],
+    oracles: list[Oracle],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    src = choice(list(accounts.values()))
+
+    # 60% create new oracle, 40% update existing (if any exist for this account)
+    account_oracles = [o for o in oracles if o.account == src.address]
+    if account_oracles and randint(0, 99) < 40:
+        # Update existing oracle — keep provider and asset_class the same
+        oracle = choice(account_oracles)
+        txn = OracleSet(
+            account=src.address,
+            oracle_document_id=oracle.document_id,
+            provider=oracle.provider,
+            asset_class=oracle.asset_class,
+            last_update_time=params.oracle_last_update_time(),
+            price_data_series=_random_price_data_series(),
+        )
+    else:
+        # Create new oracle
+        txn = OracleSet(
+            account=src.address,
+            oracle_document_id=params.oracle_document_id(),
+            provider=params.oracle_provider(),
+            asset_class=params.oracle_asset_class(),
+            last_update_time=params.oracle_last_update_time(),
+            price_data_series=_random_price_data_series(),
+        )
+    await submit_tx("OracleSet", txn, client, src.wallet)
+
+
+async def _oracle_set_faulty(
+    accounts: dict[str, UserAccount],
+    oracles: list[Oracle],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    mutation = choice(
+        [
+            "non_owner_submission",
+            "invalid_flags",
+            "invalid_update_time",
+            "provider_mismatch",
+        ]
+    )
+    accounts_list = list(accounts.values())
+
+    if mutation == "non_owner_submission":
+        if len(accounts_list) < 2:
+            return
+        owner, impostor = sample(accounts_list, 2)
+        txn = OracleSet(
+            account=owner.address,
+            oracle_document_id=params.oracle_document_id(),
+            provider=params.oracle_provider(),
+            asset_class=params.oracle_asset_class(),
+            last_update_time=params.oracle_last_update_time(),
+            price_data_series=_random_price_data_series(),
+        )
+        await submit_tx("OracleSet", txn, client, impostor.wallet)
+
+    elif mutation == "invalid_flags":
+        src = choice(accounts_list)
+        txn = OracleSet(
+            account=src.address,
+            oracle_document_id=params.oracle_document_id(),
+            provider=params.oracle_provider(),
+            asset_class=params.oracle_asset_class(),
+            last_update_time=params.oracle_last_update_time(),
+            price_data_series=_random_price_data_series(),
+            flags=0x80000000,
+        )
+        await submit_tx("OracleSet", txn, client, src.wallet)
+
+    elif mutation == "invalid_update_time":
+        src = choice(accounts_list)
+        # Use a time far in the past but after the XRPL epoch to bypass
+        # client validation — should trigger tecINVALID_UPDATE_TIME
+        stale_time = 946684800 + 1  # just after XRPL epoch, ~year 2000
+        txn = OracleSet(
+            account=src.address,
+            oracle_document_id=params.oracle_document_id(),
+            provider=params.oracle_provider(),
+            asset_class=params.oracle_asset_class(),
+            last_update_time=stale_time,
+            price_data_series=_random_price_data_series(),
+        )
+        await submit_tx("OracleSet", txn, client, src.wallet)
+
+    elif mutation == "provider_mismatch":
+        # Try to update an existing oracle with a different provider
+        if not oracles:
+            return
+        oracle = choice(oracles)
+        if oracle.account not in accounts:
+            return
+        owner = accounts[oracle.account]
+        # Generate a different provider than the one stored
+        wrong_provider = params.oracle_provider()
+        txn = OracleSet(
+            account=owner.address,
+            oracle_document_id=oracle.document_id,
+            provider=wrong_provider,
+            asset_class=oracle.asset_class,
+            last_update_time=params.oracle_last_update_time(),
+            price_data_series=_random_price_data_series(),
+        )
+        await submit_tx("OracleSet", txn, client, owner.wallet)
+
+
+# ── OracleDelete ─────────────────────────────────────────────────────
+
+
+async def oracle_delete(
+    accounts: dict[str, UserAccount],
+    oracles: list[Oracle],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if params.should_send_faulty():
+        return await _oracle_delete_faulty(accounts, oracles, client)
+    return await _oracle_delete_valid(accounts, oracles, client)
+
+
+async def _oracle_delete_valid(
+    accounts: dict[str, UserAccount],
+    oracles: list[Oracle],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not oracles:
+        return
+    target = choice(oracles)
+    if target.account not in accounts:
+        return
+    owner = accounts[target.account]
+    txn = OracleDelete(
+        account=owner.address,
+        oracle_document_id=target.document_id,
+    )
+    await submit_tx("OracleDelete", txn, client, owner.wallet)
+
+
+async def _oracle_delete_faulty(
+    accounts: dict[str, UserAccount],
+    oracles: list[Oracle],
+    client: AsyncJsonRpcClient,
+) -> None:
+    if not accounts:
+        return
+    mutation = choice(
+        [
+            "delete_nonexistent",
+            "non_owner_submission",
+            "invalid_flags",
+        ]
+    )
+    accounts_list = list(accounts.values())
+
+    if mutation == "delete_nonexistent":
+        src = choice(accounts_list)
+        txn = OracleDelete(
+            account=src.address,
+            oracle_document_id=params.oracle_document_id(),
+        )
+        await submit_tx("OracleDelete", txn, client, src.wallet)
+
+    elif mutation == "non_owner_submission":
+        if not oracles or len(accounts_list) < 2:
+            return
+        target = choice(oracles)
+        if target.account not in accounts:
+            return
+        impostors = [a for a in accounts_list if a.address != target.account]
+        if not impostors:
+            return
+        impostor = choice(impostors)
+        txn = OracleDelete(
+            account=target.account,
+            oracle_document_id=target.document_id,
+        )
+        await submit_tx("OracleDelete", txn, client, impostor.wallet)
+
+    elif mutation == "invalid_flags":
+        src = choice(accounts_list)
+        txn = OracleDelete(
+            account=src.address,
+            oracle_document_id=params.oracle_document_id(),
+            flags=0x80000000,
+        )
+        await submit_tx("OracleDelete", txn, client, src.wallet)

--- a/workload/src/workload/transactions/tickets.py
+++ b/workload/src/workload/transactions/tickets.py
@@ -13,6 +13,7 @@ from xrpl.models.transactions import (
     EscrowCreate,
     MPTokenIssuanceCreate,
     NFTokenMint,
+    OracleSet,
     Payment,
     PermissionedDomainSet,
     SetRegularKey,
@@ -22,6 +23,7 @@ from xrpl.models.transactions import (
 from xrpl.models.transactions.deposit_preauth import Credential as XRPLCredential
 from xrpl.models.transactions.mptoken_issuance_create import MPTokenIssuanceCreateFlag
 from xrpl.models.transactions.nftoken_mint import NFTokenMintFlag
+from xrpl.models.transactions.oracle_set import PriceData
 from xrpl.models.transactions.signer_list_set import SignerEntry
 from xrpl.models.transactions.transaction import Memo
 
@@ -101,6 +103,21 @@ _TICKET_BUILDERS: dict[str, _TicketBuilder] = {
         **c,
     ),
     "DIDSet": lambda dst, c: DIDSet(uri=params.did_hex_field(), **c),
+    "OracleSet": lambda dst, c: OracleSet(
+        oracle_document_id=params.oracle_document_id(),
+        provider=params.oracle_provider(),
+        asset_class=params.oracle_asset_class(),
+        last_update_time=params.oracle_last_update_time(),
+        price_data_series=[
+            PriceData(
+                base_asset=params.oracle_base_asset(),
+                quote_asset=params.oracle_quote_asset(),
+                asset_price=params.oracle_asset_price(),
+                scale=params.oracle_scale(),
+            ),
+        ],
+        **c,
+    ),
 }
 
 # Types explicitly excluded from ticket use.  Reasons:
@@ -168,6 +185,8 @@ _TICKET_EXCLUDED: set[str] = {
     "AccountDelete",
     # objects — needs an existing DID on the account
     "DIDDelete",
+    # objects — requires pre-existing oracle
+    "OracleDelete",
 }
 
 


### PR DESCRIPTION
## Summary

- Adds full Antithesis workload coverage for **Price Oracles (XLS-47)** — `OracleSet` and `OracleDelete` transaction types with valid paths, fault injection, state tracking, and protocol-invariant assertions.
- No setup phase required — Oracle objects are created implicitly by `OracleSet` and the empty-state case is handled by early return in handlers.

### New files
| File | Purpose |
|------|--------|
| `transactions/oracle.py` | OracleSet + OracleDelete handlers (valid + faulty paths) |
| `parallel_driver_oracle_set_random.sh` | Antithesis driver script for OracleSet |
| `parallel_driver_oracle_delete_random.sh` | Antithesis driver script for OracleDelete |

### Modified files
| File | Change |
|------|--------|
| `models.py` | Added `Oracle` dataclass (`account`, `document_id`, `provider`, `asset_class`) |
| `params.py` | Added 10 Oracle parameter generators (document_id, provider, asset_class, base/quote assets, asset_price, scale, price_data_count, last_update_time) |
| `app.py` | Added `self.oracles = []` to `Workload` state |
| `transactions/__init__.py` | Added `_on_oracle_set` / `_on_oracle_delete` state updaters + registry entries |
| `assertions.py` | Added `OracleSet` / `OracleDelete` to `_META_EXPECTATIONS` table + `OracleDocumentID` to `_OBJECT_ID_FIELDS` |
| `transactions/tickets.py` | Added `OracleSet` to `_TICKET_BUILDERS` + `OracleDelete` to `_TICKET_EXCLUDED` |
| `scripts/check-imports` | Added `oracle_set`, `oracle_delete`, `Oracle` imports |
| `scripts/check-endpoints` | Added `/oracle/set/random`, `/oracle/delete/random` |

## Coverage

### Valid paths
- **OracleSet**: 60% create new oracle (random doc_id, provider, asset_class, timestamp, 1–5 PriceData entries with unique base/quote pairs). 40% update existing oracle (reuses stored provider/asset_class, fresh timestamp + price data).
- **OracleDelete**: Picks a tracked Oracle from `w.oracles` and deletes it. Returns silently if none exist.

### Faulty paths — OracleSet (4 mutations)
| Mutation | Expected result |
|----------|-----------------|
| `non_owner_submission` | `tefBAD_AUTH` |
| `invalid_flags` (`0x80000000`) | `temINVALID_FLAG` |
| `invalid_update_time` (epoch + 1) | `tecINVALID_UPDATE_TIME` |
| `provider_mismatch` | Provider conflict on existing oracle |

### Faulty paths — OracleDelete (3 mutations)
| Mutation | Expected result |
|----------|-----------------|
| `delete_nonexistent` | `tecNO_ENTRY` |
| `non_owner_submission` | `tefBAD_AUTH` |
| `invalid_flags` (`0x80000000`) | `temINVALID_FLAG` |

### Assertions (Always-invariants)
- `_META_EXPECTATIONS["OracleSet"] = ("Created", "Modified", "Oracle")` — on `tesSUCCESS`, metadata must contain an Oracle `CreatedNode` or `ModifiedNode`
- `_META_EXPECTATIONS["OracleDelete"] = ("Deleted", "Oracle")` — on `tesSUCCESS`, metadata must contain an Oracle `DeletedNode`

### State tracking
- `_on_oracle_set`: Idempotent — updates existing oracle (by account + document_id) or appends new `Oracle` to `w.oracles`
- `_on_oracle_delete`: Removes oracle matching account + document_id from `w.oracles`

## Design decisions

1. **PriceData unique pairs** — `_random_price_data_series()` deduplicates base/quote pairs within a single series and guarantees at least one entry, matching the spec requirement.
2. **`invalid_update_time` uses epoch + 1** — xrpl-py blocks values before the XRPL epoch (946684800), so we use a value just after the epoch (~year 2000) which passes client validation but triggers `tecINVALID_UPDATE_TIME` server-side (>300s from ledger close).
3. **No setup phase** — Oracles don't require pre-existing ledger objects, avoiding additions to the setup dependency chain.
4. **Ticket coverage** — `OracleSet` is stateless (can create new oracle with any doc_id) so it's in `_TICKET_BUILDERS`. `OracleDelete` requires a pre-existing oracle so it's in `_TICKET_EXCLUDED`.
5. **Hex-encoded Provider/AssetClass** — xrpl-py calls `bytes.fromhex()` on these Blob fields, so generators return uppercase hex strings (e.g. `"chainlink_123"` → `"636861696E6C696E6B5F313233"`).

## Test plan

- [x] `scripts/check-imports` passes
- [x] `scripts/check-endpoints` passes (65 endpoints, 29 expected)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Antithesis run ([#1217](https://github.com/ripple/rippled-antithesis/actions/runs/25880302111)) — all assertions passed:
  - `workload::success : OracleSet` ✅ reached
  - `workload::success : OracleDelete` ✅ reached
  - `workload::failure : OracleSet` ✅ reached (faulty paths exercised)
  - `workload::seen : OracleSet` ✅ reached
  - `workload::endpoint_exception` ✅ resolved (hex-encoding fix)
  - No existing assertions regressed

## Known xrpl-py limitations

The following scenarios are blocked by xrpl-py client-side validation before reaching rippled:
| Scenario | Ledger error | Why blocked |
|----------|-------------|-------------|
| Empty `PriceDataSeries` | `temARRAY_EMPTY` | xrpl-py requires `len(price_data_series) > 0` |
| >10 `PriceData` entries | `temARRAY_TOO_LARGE` / `tecARRAY_TOO_LARGE` | xrpl-py enforces `len <= 10` |
| `LastUpdateTime` before XRPL epoch | `temMALFORMED` | xrpl-py enforces `>= 946684800` |

## References
- [XLS-47 Price Oracle Specification](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0047d-price-oracles)
- [OracleSet docs](https://xrpl.org/docs/references/protocol/transactions/types/oracleset) · [OracleDelete docs](https://xrpl.org/docs/references/protocol/transactions/types/oracledelete)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author