### PR TITLE
Add /ready endpoint and wire workload_ready_url for fuzzer coordination

### DIFF
--- a/prepare-workload/prepare_workload/templates/fuzzer.cfg.mako
+++ b/prepare-workload/prepare_workload/templates/fuzzer.cfg.mako
@@ -37,6 +37,11 @@ ${seed}
 [validation_seed]
 ${validation_seed}
 
+# Workload /ready endpoint. Fuzzer probes this before arming mutators
+# so faults do not fire during workload setup.
+[workload_ready_url]
+http://workload:8000/ready
+
 # Protocol feature negotiation flags.
 # These control which features the fuzzer advertises in its handshake
 # (X-Protocol-Ctl header), which determines what message types peers

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -173,7 +173,11 @@ def create_app(workload: Workload) -> FastAPI:
     import contextlib
     from contextlib import asynccontextmanager
 
+    from fastapi import Response
+
     from workload.ws_listener import start_ws_listener
+
+    ready = {"value": False}
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -193,6 +197,7 @@ def create_app(workload: Workload) -> FastAPI:
             )
 
         lifecycle.setup_complete(details={"message": "Setup complete, faults may begin"})
+        ready["value"] = True
         yield  # app runs here, shutdown after yield
 
         ws_task.cancel()
@@ -200,6 +205,10 @@ def create_app(workload: Workload) -> FastAPI:
             await ws_task
 
     app = FastAPI(lifespan=lifespan)
+
+    @app.get("/ready")
+    def _ready() -> Response:
+        return Response(status_code=200 if ready["value"] else 503)
 
     global get_workload
 


### PR DESCRIPTION
## What
- Add a `/ready` HTTP endpoint that returns `503` until workload setup completes and `200` afterward.
- Emit a `[workload_ready_url]` section in the generated `fuzzer.cfg` pointing at `http://workload:8000/ready`.

## Why
The fuzzer probes this endpoint to learn when the workload has finished its initial setup, so fault injection only begins once the network is steady — faults firing mid-setup produce noise rather than meaningful signal.

## Notes
- No change to transaction generation or existing endpoints.
- `check-imports` and `check-endpoints` pass; the `/ready` route registers.