### PR TITLE
Trim verbose docstrings, comments, and AI instructions

### DIFF
--- a/.claude/agents/experiment-analyst.md
+++ b/.claude/agents/experiment-analyst.md
@@ -6,71 +6,46 @@ tools: Glob, Grep, Read, Bash, WebFetch, WebSearch
 
 You analyze Antithesis experiment results for the XRP Ledger workload.
 
-## Assertion naming in triage reports
-
-- `workload::seen : TxType` — transaction submitted at least once
-- `workload::success : TxType` — at least one tesSUCCESS
-- `workload::failure : TxType` — at least one non-tesSUCCESS
-- `workload::always : valid_engine_result` — engine_result always a valid string
-- `workload::always : no_internal_rippled_error` — tefEXCEPTION/tefINTERNAL/tefINVARIANT_FAILED never occur
-- `workload::setup_*` — per-step reachability (gateways, trust_lines, iou_distribution, mpt_*, vaults, nfts, credentials, tickets, domains, loan_brokers, cover_deposits, loans)
-- `workload::endpoint_exception` (unreachable) — should never fire
+## Assertion names
+- `workload::seen : TxType` — submitted ≥ once.
+- `workload::success : TxType` — ≥ one tesSUCCESS.
+- `workload::failure : TxType` — ≥ one non-tesSUCCESS.
+- `workload::always : valid_engine_result` — engine_result always a valid string.
+- `workload::always : no_internal_rippled_error` — tefEXCEPTION/tefINTERNAL/tefINVARIANT_FAILED never occur.
+- `workload::setup_*` — per-step reachability.
+- `workload::endpoint_exception` (unreachable) — must never fire.
 
 ## Genesis ledger
-
-- `genesis/genesis_ledger.json` — committed base with 100 pre-funded SECP256K1 accounts, amendments empty
-- `genesis/accounts.json` — account seeds for wallet derivation
-- CI injects amendment hashes from `features.macro` (SHA-512Half of name, pure Python, no xrpld binary)
-- All validators + xrpld must start from same ledger or consensus breaks
-- `wait_for_network` requires 3 consecutive sync checks before calling `setup_complete()`
+- `genesis/genesis_ledger.json` — committed base, 100 pre-funded SECP256K1 accounts, empty amendments.
+- `genesis/accounts.json` — seeds for wallet derivation.
+- CI injects amendment hashes from `features.macro` (SHA-512Half of name, pure Python).
+- All validators + xrpld start from the same ledger or consensus breaks.
+- `wait_for_network` needs 3 consecutive sync checks before `setup_complete()`.
 
 ## CI pipeline (ripple/rippled-antithesis)
+1. Checkout workload + rippled (sparse, only `features.macro`).
+2. Build xrpld image.
+3. Network config: validator keys, compose files → `testnet/`.
+4. Inject amendments into genesis → `testnet/volumes/*/`.
+5. Build sidecar/workload/config images → push → launch.
 
-1. Checkout workload + rippled (sparse, only `features.macro`)
-2. Build xrpld Docker image
-3. Generate network config: validator keys, compose files → `testnet/`
-4. Inject amendments into committed genesis → copy to `testnet/volumes/*/`
-5. Build sidecar, workload, config images → push → launch experiment
+Config image mounts: xrpld `testnet/volumes/val0/` → `/opt/xrpld/etc/`; workload `/accounts.json`, `/genesis_ledger.json` from image root.
 
-Config image mounts:
-- xrpld: `testnet/volumes/val0/` → `/opt/xrpld/etc/` (cfg + genesis)
-- Workload: `/accounts.json`, `/genesis_ledger.json` from config image root
+Repos: `ripple/rippled-antithesis` (CI), `ripple/rippled-workload` (workload), both main.
 
-## Two repos
-
-- `ripple/rippled-antithesis` — CI workflow (main branch)
-- `ripple/rippled-workload` — workload code (main branch)
-
-## Getting the data (REST API)
-
-Prefer fetching from the Antithesis read API over a manual download. Either a **run selector** or a
-**local file/dir** is a valid input:
-
+## Getting the data
+Prefer the read REST API over manual download. Selector or local dir both valid.
 ```bash
-# Resolve + save run.json, properties.json, failing.txt, events.ndjson under ~/Downloads/antithesis/<run_id>/
 python3 scripts/antithesis_fetch.py fetch <selector>
-#   selector: latest | latest-failing | gh=<github_run_id> | match=<substr> | <run_id>
-python3 scripts/antithesis_fetch.py properties <selector> --failing   # quick assertion triage
+#   selector: latest | latest-failing | gh=<id> | match=<substr> | <run_id>
+python3 scripts/antithesis_fetch.py properties <selector> --failing   # assertion triage
 ```
+Auth: `$ANTITHESIS_API_KEY` or `~/antithesis.key` (`pass:` line); tenant `$ANTITHESIS_TENANT` (default `ripple`). Endpoints: `/api/v0/runs`, `/runs/{id}`, `/runs/{id}/properties`, `/runs/{id}/logs?input_hash=&vtime=` (full stream; `/events` is a capped stdout search).
 
-Auth: `$ANTITHESIS_API_KEY` or `~/antithesis.key` (`pass:` line); tenant `$ANTITHESIS_TENANT`
-(default `ripple`). Endpoints: `GET /api/v0/runs`, `/runs/{id}`, `/runs/{id}/properties`,
-`/runs/{id}/logs?input_hash=&vtime=` (the full event stream; `/events` is only a capped stdout
-text-search). The script is in the rippled-workload repo at `scripts/antithesis_fetch.py`.
+`properties.json` is authoritative. Separate real failures from coverage gaps: a real failure is `always`/`AlwaysOrUnreachable` with `condition:false` (rippled `*.cpp` or sidecar). `workload::failure|success|seen : <Tx>` and `fuzzer::seen|faulted` showing "Failing" just means that `sometimes`/`reachable` path went unexercised — a coverage gap, not a server bug.
 
-`properties.json` is the authoritative assertion view. **Separate real failures from coverage gaps:**
-a genuinely failing invariant is `always`/`AlwaysOrUnreachable` with `condition:false` (e.g. a
-rippled `src/.../*.cpp` or sidecar assertion). Names like `workload::failure|success|seen : <Tx>` and
-`fuzzer::seen|faulted : <msg>` show "Failing" merely because that `sometimes`/`reachable` path was
-never exercised — that's a coverage gap (too-conservative `_valid`, missing `_faulty`, or unreached
-setup), not a server bug.
-
-## Analyzing events.ndjson
-
-`events.ndjson` is pure NDJSON (one JSON object per line, **no log prefix**). SDK event names are
-top-level keys (`"workload::result : Payment"`, `"val_health"`, `"fault"`, …). Parse with
-`json.loads(line)` directly:
-
+## events.ndjson
+Pure NDJSON, no log prefix. SDK event names are top-level keys (`"workload::result : Payment"`, `"val_health"`, `"fault"`). Parse with `json.loads(line)`.
 ```bash
 # Engine-result breakdown
 python3 -c "
@@ -85,7 +60,7 @@ for line in open(sys.argv[1]):
 for k,v in er.most_common(): print(f'{v:6d} {k}')
 " events.ndjson
 
-# Fault-injection breakdown (which faults ran)
+# Fault-injection breakdown
 python3 -c "
 import json,collections,sys
 f=collections.Counter()
@@ -97,30 +72,25 @@ for line in open(sys.argv[1]):
 print(dict(f.most_common()))
 " events.ndjson
 
-# Endpoint exceptions (should be zero) / setup
 grep -c 'workload::endpoint_exception' events.ndjson
 grep 'workload::setup_reject\|workload::setup_error' events.ndjson
 ```
+Legacy `events(N).log` has a ` - {json}` prefix: `json.loads(line.split(' - ',1)[1])`.
 
-Legacy fallback: an old downloaded `events(N).log` has a ` - {json}` prefix and event-name-as-text —
-parse those lines with `json.loads(line.split(' - ',1)[1])`.
-
-## Triage report patterns
-
-- **[new] failure** — assertion was passing, now failing (regression or new code path)
-- **[resolved]** — was failing, now passing (fix worked)
-- **[ongoing]** — still failing (known issue)
-- `sometimes(failure)` never fires → `_valid` path too conservative, needs broader state exploration or `_faulty` implementation
-- `sometimes(success)` never fires → transaction structurally broken (wrong params, missing prerequisites, wrong submitter)
-- `reachability` fails → setup step returned count=0, or endpoint never called
+## Triage patterns
+- `[new] failure` — was passing, now failing (regression / new path).
+- `[resolved]` — fixed. `[ongoing]` — known issue.
+- `sometimes(failure)` never fires → `_valid` too conservative, or missing `_faulty`.
+- `sometimes(success)` never fires → tx structurally broken (params/prereqs/submitter).
+- `reachability` fails → setup step count=0, or endpoint never called.
 
 ## Common root causes
-
 | Symptom | Likely cause |
 |---------|-------------|
-| All setup_* fail | `notSynced` race — check `wait_for_network` stability |
-| `tecPATH_DRY` on IOU payments | Trust lines not created (cascading from setup failure) |
-| `tefPAST_SEQ` on some txns | Same-account sequence race (acceptable in small numbers) |
-| `tecINSUFFICIENT_FUNDS` on loans | Missing `LoanBrokerCoverDeposit` step |
+| All setup_* fail | `notSynced` race — check `wait_for_network` |
+| `tecPATH_DRY` on IOU payments | Trust lines missing (setup cascade) |
+| `tefPAST_SEQ` | Same-account sequence race (OK in small numbers) |
+| `tecINSUFFICIENT_FUNDS` on loans | Missing `LoanBrokerCoverDeposit` |
 | `temBAD_SIGNER` on LoanSet | Missing counterparty co-signing |
-| `tecHAS_OBLIGATIONS` on LoanDelete | Loan not fully paid off yet |
+| `tecHAS_OBLIGATIONS` on LoanDelete | Loan not paid off |
+</content>

--- a/.claude/agents/workload-developer.md
+++ b/.claude/agents/workload-developer.md
@@ -4,16 +4,17 @@ description: "Use this agent for implementing, fixing, or auditing transaction t
 tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch
 ---
 
-You are a Python developer working on the Antithesis workload generator for XRP Ledger fuzzing.
+You develop the Antithesis workload generator for XRP Ledger fuzzing.
 
-Key files you'll work with most:
-- `workload/src/workload/transactions/__init__.py` — REGISTRY (single source of truth for all tx types)
-- `workload/src/workload/params.py` — random parameter generators
-- `workload/src/workload/setup.py` — deterministic first_* phase setup
-- `workload/src/workload/models.py` — state tracking dataclasses
+Key files (`workload/src/workload/`):
+- `transactions/__init__.py` — `REGISTRY` (single source of truth).
+- `params.py` — random parameter generators.
+- `setup.py` — deterministic first_* setup.
+- `models.py` — state-tracking dataclasses.
 
-When auditing a transaction type for error path coverage:
-1. Read the XRPL spec for all fields and error codes (see CLAUDE.md for where specs live)
-2. Classify each as `_valid`-reachable (state conflicts a real workload encounters) vs `_faulty`-only (deliberately malformed)
-3. Broaden `_valid` to explore more state space (update existing objects, target others' objects, use stale references)
-4. Implement `_faulty` for errors requiring deliberately invalid fields — pick ONE random mutation via `choice()`, submit via `submit_tx`
+Auditing a tx type for error-path coverage:
+1. Read the XRPL spec for all fields and error codes (CLAUDE.md has spec locations).
+2. Classify each error as `_valid`-reachable (real state conflict) vs `_faulty`-only (deliberately malformed).
+3. Broaden `_valid` to explore more state (update objects, target others', use stale refs).
+4. Implement `_faulty` for errors needing invalid fields — one random mutation via `choice()`, submit via `submit_tx`.
+</content>

--- a/.claude/rules/antithesis.md
+++ b/.claude/rules/antithesis.md
@@ -1,30 +1,20 @@
 # Antithesis Rules
 
 ## SDK assertions
-
-- `assert_raw()` is the only reliable way to register assertions with dynamic names — f-strings are invisible to the static scanner
-- `TX_TYPES` is derived from `REGISTRY` in `transactions/__init__.py` — the single source of truth. Every entry gets `seen`, `success`, and `failure` catalog entries registered at startup via `register_assertions()`
-- `reachable` — must be reached at least once (tx submitted)
-- `sometimes(success)` — must succeed at least once
-- `sometimes(failure)` — must fail at least once (verifies error paths exercised)
-- `always` — must hold every time evaluated (invariants)
-- `unreachable` — must never be reached (fatal errors like missing accounts.json)
+- `assert_raw()` is the only way to register dynamic-name assertions — f-strings are invisible to the static scanner.
+- `TX_TYPES` derives from `REGISTRY` (single source of truth). Each entry gets `seen`/`success`/`failure` at startup via `register_assertions()`.
+- `reachable` — reached ≥ once. `sometimes(success)` — succeeds ≥ once. `sometimes(failure)` — fails ≥ once. `always` — invariant. `unreachable` — must never fire (fatal errors).
 
 ## SDK handler chain (Python)
-
-`VoidstarHandler` (/usr/lib/libvoidstar.so, injected by Antithesis) → `LocalHandler` (ANTITHESIS_SDK_LOCAL_OUTPUT env var) → `NoopHandler` (silent, discards everything)
-
-Outside Antithesis: `export ANTITHESIS_SDK_LOCAL_OUTPUT=/path/to/file.jsonl`
+`VoidstarHandler` (libvoidstar.so, injected by Antithesis) → `LocalHandler` (`ANTITHESIS_SDK_LOCAL_OUTPUT`) → `NoopHandler` (silent). Outside Antithesis: `export ANTITHESIS_SDK_LOCAL_OUTPUT=/path/file.jsonl`.
 
 ## Test composer phases
-
 ```
 setup_complete() -> [first_*] -> [drivers + anytime_*] -> [eventually_* / finally_*]
                     no faults     faults active           faults stopped
 ```
-
-Current state: only `first_*` and `parallel_driver_*` implemented.
+Implemented: `first_*`, `parallel_driver_*`.
 
 ## Network topology
-
-The workload submits to a **non-validating tracking node** (`xrpld`), intentionally isolated from Antithesis fault injection. The 6 validators (`val0`–`val4` + `fuzzer`) are subject to faults. Do not change the submission target — submitting to a validator would introduce fault-induced jitter into transaction results.
+Workload submits to the non-validating tracking node (`xrpld`), isolated from fault injection. The 6 validators (`val0`–`val4`, `fuzzer`) take faults. Don't retarget submission to a validator — fault jitter would corrupt transaction results.
+</content>

--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -1,35 +1,30 @@
 # Coding Rules
 
-## Planning before implementation
-For non-trivial tasks, start with open questions and an outline — don't jump straight to a complete plan or code. Present your questions, get answers, propose an approach, get feedback, then implement. Use Plan Mode for multi-step work.
+## Brevity
+Code is the documentation. Comment only the WHY, never the WHAT. Drop docstrings that restate the signature; keep ones that record a non-obvious reason or gotcha. No filler prose in `.claude/` docs or `CLAUDE.md` — facts and gotchas only.
+
+## Planning
+For non-trivial work, surface open questions and an outline before coding; get answers, then implement. Use Plan Mode for multi-step changes.
 
 ## No tech debt
-Clean up dead code immediately in the same change. No unused imports, orphaned CLI flags, stale templates, or dead functions left behind.
+Remove dead code in the same change — no unused imports, orphaned flags, stale templates, or dead functions. No TODOs without agreement.
 
-## No AI co-authored commits
-Never add AI Co-Authored-By lines (e.g. Claude, Copilot) to git commits. Human co-authors are fine.
+## Refactors
+Take the large refactor if it makes the code more idiomatic or cuts maintenance. No half-measures.
 
-## Brief commit messages
-One-liner commit messages only, like all existing commits in this repo.
+## Docs in sync
+A code change that affects structure, conventions, submission patterns, assertion registration, setup steps, or CI must update the relevant `.claude/` docs and `CLAUDE.md` in the same change.
 
-## Don't shy away from large refactors
-If a refactor makes the code better, more idiomatic, or reduces maintenance burden — do it. Don't propose half-measures out of reluctance to touch many files.
+## Commits
+One-liner messages, like the existing history. No AI Co-Authored-By lines (human co-authors fine).
 
-## Keep docs in sync with code
-When a code change affects project structure, conventions, submission patterns, assertion registration, setup steps, or CI pipeline — update the relevant `.claude/` docs and `CLAUDE.md` in the same change.
-
-## Always run checks before pushing
+## Before pushing
 ```bash
 nix develop --command bash -c "scripts/check-imports && scripts/check-endpoints"
-```
-
-## Python style
-Type annotations required on all functions. Line length 100 chars. Run `ruff check` and `ruff format` before committing:
-```bash
 nix develop --command bash -c "cd workload && ruff check src/workload/ && ruff format --check src/workload/"
 ```
+Type annotations on all functions. Line length 100.
 
 ## Test composer scripts
-- All `parallel_driver_*.sh` must use `curl --silent`
-- Setup runs during FastAPI startup (before `setup_complete()`) — no `first_*` scripts needed
-- Never reference a non-existent endpoint
+`parallel_driver_*.sh` use `curl --silent`. Setup runs at FastAPI startup (no `first_*` scripts). Never reference a non-existent endpoint.
+</content>

--- a/.claude/skills/debug-antithesis-run.md
+++ b/.claude/skills/debug-antithesis-run.md
@@ -1,13 +1,8 @@
 # Debug Antithesis Run
 
-How to diagnose issues from an Antithesis experiment.
+Diagnose issues from an Antithesis experiment. The triage report ships `events(N).log` — download and grep it.
 
-## Get the events log
-
-Antithesis provides `events(N).log` in the triage report. Download and search it.
-
-## Key patterns to grep
-
+## Grep patterns
 ```bash
 # Workload assertion failures
 grep "workload::" events.log | grep '"condition":false\|"hit":true.*Unreachable'
@@ -22,32 +17,21 @@ for line in sys.stdin:
     except: pass
 "
 
-# Validator crashes
-grep "fatal\|Unable to open\|SIGABRT\|condition.:false" events.log | head -20
-
-# accounts.json missing
+grep "fatal\|Unable to open\|SIGABRT\|condition.:false" events.log | head -20   # validator crashes
 grep "accounts_json" events.log
-
-# Setup assertions (did /setup work?)
-grep "workload::setup" events.log | grep '"hit": true'
+grep "workload::setup" events.log | grep '"hit": true'                          # did /setup work?
 ```
 
-## Common issues and fixes
-
+## Common issues
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `accounts_json_missing` fires | accounts.json not mounted in workload container | Check docker-compose volume mounts survive the workflow's compose manipulation |
-| `endpoint_exception` fires | Handler name shadows import | Rename inner async def with `_endpoint` suffix |
-| All tx assertions fail (never seen) | Accounts not loaded / endpoint returning None | Check accounts.json exists, check for early returns |
-| Validators crash instantly | genesis_ledger.json not found | Confirm genesis_ledger.json is in each node's volume dir |
-| `Unable to open /genesis_ledger.json` | Wrong path in xrpld command | Path must be `/opt/xrpld/etc/genesis_ledger.json` (in node volume) |
+| `accounts_json_missing` | accounts.json not mounted in workload container | Check compose volume mounts survive the workflow's compose manipulation |
+| `endpoint_exception` | Handler name shadows import | Rename inner async def with `_endpoint` suffix |
+| All tx assertions never seen | Accounts not loaded / endpoint returns None | Check accounts.json exists, check early returns |
+| Validators crash instantly | genesis_ledger.json not found | Confirm it's in each node's volume dir |
+| `Unable to open /genesis_ledger.json` | Wrong path | Must be `/opt/xrpld/etc/genesis_ledger.json` |
 
-## Verify SDK pipeline working
-
-If `workload::started` and `workload::sdk_works` appear in triage but tx assertions don't:
-- SDK is working (VoidstarHandler active)
-- Transactions aren't being submitted — check account loading, check for exceptions
-
-If nothing appears:
-- Check if workload container even started
-- VoidstarHandler may not be getting injected — check `/usr/lib/libvoidstar.so` exists in container
+## SDK pipeline check
+- `workload::started` + `workload::sdk_works` present but no tx assertions → SDK works (VoidstarHandler active); txns not submitted (check account loading / exceptions).
+- Nothing present → container didn't start, or `/usr/lib/libvoidstar.so` not injected.
+</content>

--- a/.claude/skills/fetch-antithesis-results/SKILL.md
+++ b/.claude/skills/fetch-antithesis-results/SKILL.md
@@ -6,49 +6,22 @@ argument-hint: "[latest | latest-failing | gh=<id> | match=<substr> | <run_id>] 
 allowed-tools: [Bash(python3 scripts/antithesis_fetch.py *), Bash(python3 *)]
 ---
 
-Pull an Antithesis experiment's results via the read REST API — no manual triage-report download —
-then hand the saved artifacts to the `experiment-analyst` agent.
+Pull an Antithesis run's results via the read REST API, then hand the artifacts to the `experiment-analyst` agent.
 
 ## Auth
-
-The fetch script needs a Bearer token: `$ANTITHESIS_API_KEY`, or a key file (`$ANTITHESIS_KEY_FILE`,
-default `~/antithesis.key`; a bare token or a `pass: <token>` line). If neither is present, tell the
-user to set it and stop. Tenant defaults to `ripple` (`$ANTITHESIS_TENANT`).
+Bearer token from `$ANTITHESIS_API_KEY` or a key file (`$ANTITHESIS_KEY_FILE`, default `~/antithesis.key`; bare token or `pass: <token>` line). If neither exists, tell the user and stop. Tenant `$ANTITHESIS_TENANT` (default `ripple`).
 
 ## Steps
-
-1. Parse `$ARGUMENTS`. First token is the run **selector** (default `latest` if omitted):
-   - `latest` — most recent run
-   - `latest-failing` — most recent run with status `incomplete`
-   - `gh=<id>` — run launched by that GitHub Actions run id (matches `run=<id>` in the description)
-   - `match=<substr>` — most recent run whose description contains the substring (e.g. a branch name)
-   - a literal `<run_id>`
-   Optional `save_dir=<path>` overrides where artifacts are written.
-
-2. From the rippled-workload repo root, run the fetch (it resolves the run, saves artifacts, and
-   prints a summary):
+1. Parse `$ARGUMENTS`. First token is the selector (default `latest`): `latest` | `latest-failing` (status `incomplete`) | `gh=<id>` (GitHub Actions run id, matches `run=<id>` in description) | `match=<substr>` (latest run whose description contains it) | `<run_id>`. Optional `save_dir=<path>`.
+2. From the repo root:
    ```
    python3 scripts/antithesis_fetch.py fetch <selector> [--save-dir <path>]
    ```
-   This writes to `<save_dir|~/Downloads/antithesis>/<run_id>/`:
-   - `run.json` — status, commits/refs, `links.triage_report` (signed URL)
-   - `properties.json` — every assertion outcome
-   - `failing.txt` — the non-passing assertions with source `file:line`
-   - `events.ndjson` — the full event stream via `/logs` at the latest moment: SDK events
-     (`workload::result : <Tx>`, `val_health`, `fault`, …) plus all container stdout/stderr
-
-3. Print the script's summary (status, triage link, failing count) to the user.
-
-4. Hand off to the **experiment-analyst** agent for root-cause analysis. Give it the saved directory
-   path and point it at `failing.txt`, `properties.json`, and `events.ndjson`. Tell it to separate
-   genuinely failing invariants (`always`/`AlwaysOrUnreachable` with `condition:false`, e.g. a
-   rippled or sidecar assertion) from unsatisfied **coverage** assertions that merely show as
-   "Failing" when not yet exercised (`workload::failure|success|seen : <Tx>`, `fuzzer::seen|faulted`).
+   Writes to `<save_dir|~/Downloads/antithesis>/<run_id>/`: `run.json` (status, refs, `links.triage_report`), `properties.json` (every assertion outcome), `failing.txt` (non-passing + source `file:line`), `events.ndjson` (full `/logs` stream + container stdout/stderr).
+3. Print the script summary (status, triage link, failing count).
+4. Hand off to **experiment-analyst** with the saved dir. Tell it to separate real failures (`always`/`AlwaysOrUnreachable` + `condition:false`, rippled/sidecar) from coverage gaps (`workload::failure|success|seen : <Tx>`, `fuzzer::seen|faulted`).
 
 ## Notes
-
-- `events.ndjson` is pure NDJSON — one JSON object per line, **no log prefix**. Parse with
-  `json.loads(line)`; SDK event names are top-level keys (e.g. `"workload::result : Payment"`).
-- For a deep dive on a specific failing assertion, its counterexample carries a `moment`
-  (`input_hash`,`vtime`); fetch the surrounding window with
-  `python3 scripts/antithesis_fetch.py logs <run_id> --input-hash H --vtime V [--begin-input-hash H0 --begin-vtime V0]`.
+- `events.ndjson` is pure NDJSON, no log prefix; event names are top-level keys (`"workload::result : Payment"`).
+- Deep dive on a failing assertion: its counterexample carries a `moment` (`input_hash`,`vtime`); fetch the window with `python3 scripts/antithesis_fetch.py logs <run_id> --input-hash H --vtime V [--begin-input-hash H0 --begin-vtime V0]`.
+</content>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,104 +1,88 @@
 # rippled-workload
 
-Antithesis workload generator for XRP Ledger (rippled) fuzzing. Generates random XRPL transactions via a FastAPI HTTP server, driven by Antithesis test composer shell scripts.
+Antithesis workload generator for rippled fuzzing. FastAPI server emits random XRPL transactions; Antithesis test-composer shell scripts drive the endpoints.
 
-## Development Setup
+## Setup
 
-### Prerequisites
-- Nix with flakes enabled
-- direnv (optional, auto-activates devshell)
-
-### Quick Start
 ```bash
-cd rippled-workload
-nix develop          # or direnv auto-enters via .envrc
-check-imports        # verify all imports resolve (~2s)
-check-endpoints      # start app, verify all endpoints register (~3s)
+nix develop        # or direnv via .envrc
+check-imports      # imports resolve (~2s)
+check-endpoints    # endpoints register (~3s)
 ```
 
-## Adding a New Transaction Type
+## Add a transaction type
 
-1. **`params.py`** — Add parameter generators for all randomizable fields.
-2. **New module** in `transactions/` — dispatch + `_valid` + `_faulty` (stub):
+1. `params.py` — parameter generators for every randomizable field.
+2. `transactions/<name>.py` — dispatch + `_valid` + `_faulty`:
    ```python
    async def escrow_create(accounts, escrows, client):
        if params.should_send_faulty():
            return await _escrow_create_faulty(...)
        return await _escrow_create_valid(...)
    ```
-3. **`models.py`** — Add a dataclass if the object needs state tracking.
-4. **`transactions/__init__.py`** — Add entry to `REGISTRY` (see Patterns below).
-5. **`test_composer/`** — Add `parallel_driver_<name>_random.sh` with `curl --silent`.
-6. **`scripts/check-imports`** — Add the new module import.
-7. **`scripts/check-endpoints`** — Add the new endpoint path to `expected`.
-8. **`transactions/tickets.py`** — Classify the new type in `_TICKET_BUILDERS` or `_TICKET_EXCLUDED`. Builders take a `TicketCtx` (src account, dst, `common`, and workload state: accounts/domains/credentials/amms) and return a `Transaction` or `None` to skip; state-aware types (e.g. permissioned DEX) read `ctx.domains`/`ctx.amms`. Only truly impossible types (need object IDs the ctx can't supply, cosign, circular, batch) go in `_TICKET_EXCLUDED`. Every `REGISTRY` type must be in one or the other, or `check_ticket_coverage` fires `unreachable : ticket_coverage_missing`.
-9. **`setup.py`** — Add creation logic if other transactions depend on this object existing.
-10. Run `check-imports` and `check-endpoints` before pushing.
+3. `models.py` — dataclass if the object needs state tracking.
+4. `transactions/__init__.py` — `REGISTRY` entry.
+5. `test_composer/parallel_driver_<name>_random.sh` — `curl --silent`.
+6. `scripts/check-imports` — add the module import.
+7. `scripts/check-endpoints` — add the endpoint path to `expected`.
+8. `transactions/tickets.py` — classify in `_TICKET_BUILDERS` or `_TICKET_EXCLUDED`. Builders take a `TicketCtx` (src/dst, `common`, workload state) and return a `Transaction` or `None`. Only types that can't be built from the ctx (need object IDs, cosign, circular, batch) go in `_TICKET_EXCLUDED`. Every `REGISTRY` type must be in one; else `check_ticket_coverage` fires `unreachable : ticket_coverage_missing`.
+9. `setup.py` — creation logic if other transactions depend on the object.
+10. Run `check-imports` and `check-endpoints`.
 
 ## Patterns
 
-### REGISTRY shape
-Each entry in `REGISTRY` (`transactions/__init__.py`) is a 5-tuple:
-```python
-(name, path, handler_fn, args_fn, state_updater | None)
-# name: PascalCase XRPL TransactionType ("VaultCreate")
-# path: HTTP endpoint ("/vault/create/random")
-# handler_fn: async def handler(args..., client) -> None
-# args_fn: lambda w: (w.accounts, w.vaults, ...) — extracts Workload state
-# state_updater: def updater(w, tx, meta) -> None — or None if not needed
-```
+### REGISTRY (`transactions/__init__.py`)
+5-tuple: `(name, path, handler_fn, args_fn, state_updater | None)`.
+- `name` — PascalCase TransactionType (`"VaultCreate"`).
+- `path` — endpoint (`"/vault/create/random"`).
+- `args_fn` — `lambda w: (w.accounts, w.vaults, ...)`.
+- `state_updater` — `def(w, tx, meta)`, or `None`.
 
 ### State updaters
-Called by WS listener on `tesSUCCESS`. Parse created/deleted objects from `meta["AffectedNodes"]` using `_extract_created_id(meta, entry_type)` / `_extract_deleted_id(meta, entry_type)`. Must update **both** global lists (`w.nfts`, `w.vaults`, etc.) and per-account state (`w.accounts[addr].nfts`) to keep them in sync.
+WS listener calls on `tesSUCCESS`. Parse `meta["AffectedNodes"]` via `_extract_created_id`/`_extract_deleted_id`. Update **both** the global list (`w.vaults`) and per-account state (`w.accounts[addr].nfts`).
 
 ### Handler preconditions
-Return early silently when state is empty — never raise, never log. Non-XRPL exceptions trigger `unreachable()` assertions and fail the test.
-```python
-if not nfts:
-    return
-```
+Return early silently on empty state — never raise, never log. Non-XRPL exceptions trip `unreachable()` and fail the test.
 
-### Transaction submission
-Always use `submit_tx()` from `submit.py` — it wires `tx_submitted()` assertions automatically. Never call `xrpl_submit` directly. Exception: `LoanSet` uses manual co-signing in `lending.py`.
+### Submission
+`submit_tx()` (`submit.py`) always — it wires `tx_submitted()`. Never call `xrpl_submit` directly (exception: `LoanSet` co-signs in `lending.py`).
 
-For deliberately malformed transactions that xrpl-py's model validation rejects at **construction** (e.g. `tfHybrid` without `DomainID` → `temINVALID_FLAG`, empty/`>10`/duplicate `AcceptedCredentials` → `temARRAY_EMPTY`/`temARRAY_TOO_LARGE`/`temMALFORMED`), use `submit_raw(name, base, mutate, client, wallet)` from `submit.py`. It autofills a **valid** `base` model (for Sequence/Fee/LastLedgerSequence), serializes to an XRPL dict, applies `mutate(dict)` to introduce the malformation, then signs and submits the raw blob — so rippled's own preflight is what rejects it. It wires `tx_submitted` identically. Use ONLY in `_faulty` paths. `tx_submitted` accepts either a model or the raw dict. (Permissioned DEX is the first adopter; other workloads' faulty handlers can migrate to this for vectors currently unreachable through models.)
+`submit_raw(name, base, mutate, client, wallet)` for malformations xrpl-py rejects at construction (`tfHybrid` w/o `DomainID`, empty/`>10`/duplicate arrays). Autofills a valid `base`, serializes, applies `mutate(dict)`, signs and submits raw so rippled preflight does the rejecting. `_faulty` only. `mutate` MUST keep the dict encodable — no encode guard (only `submit_fuzzed` catches that).
 
 ### Faulty handlers
-Each `_faulty` handler picks ONE random mutation via `choice()`, constructs a deliberately invalid transaction, and submits via `submit_tx` (or `submit_raw` for model-rejected shapes — see above). Must never raise — precondition checks same as `_valid`. Common mutations: `params.fake_id()` (nonexistent object), `params.zero_domain_id()` (all-zero DomainID → `temMALFORMED`), non-owner submission, zero/negative amounts, mismatched asset types, overdraw (`balance + randint(...)`). Keep overdraw/state-aware mutations in `_faulty` only — `_valid` handlers must use amounts within tracked balances.
+One random mutation via `choice()`; never raise; same preconditions as `_valid`. Mutations: `fake_id()`, `zero_domain_id()` (→ `temMALFORMED`), non-owner submit, zero/negative amounts, mismatched assets, overdraw. Keep overdraw/state-aware mutations out of `_valid`.
 
-Bucket coverage caveat: `tem*`/`tef*` vectors never enter a ledger, so they never reach `ws_listener`/`tx_result` — they feed only the `seen` bucket plus the submit-time `no_internal_rippled_error_submit` check, NOT the `success`/`failure` `sometimes` buckets. The `sometimes(failure)` bucket for a type is satisfied only by its tec-producing vectors (which DO validate); make sure each `_faulty` handler keeps at least one tec-producing vector or its failure assertion will starve.
+`tem*`/`tef*` vectors never enter a ledger, so they feed only `seen` + the submit-time `no_internal_rippled_error_submit` check — NOT the `success`/`failure` buckets. Keep ≥1 tec-producing vector per `_faulty` or `sometimes(failure)` starves.
 
 ### Generative fuzzing (`fuzz.py`)
-The curated mutations above encode *predicted* faults. `fuzz.py` adds **true generative fuzzing** to the faulty path for the unknown-unknowns: `submit_fuzzed(name, base, client, wallet)` takes a VALID base model and applies 1–3 random, type-inferred-but-open-ended mutations to its serialized dict (boundary/zero/max values, hostile hashes/accounts, empty/oversize/duplicated arrays, field drops), keeping it **encodable and validly signed** so it reaches rippled's preflight/preclaim/doApply (not just the binary parser). Auth/sequence/fee fields are left intact (`_PROTECTED`). It rides `submit_raw`, emits `workload::fuzz` with the exact operators applied + engine_result (and `workload::fuzz_skipped` if a shape won't serialize) for reproducible triage. Wired as one `"fuzz"` choice **alongside** the curated mutations in each pdex `_faulty` handler (factor out a `_*_base()` builder so valid + fuzz share it). Permissioned DEX is the first adopter; other workloads can opt in the same way. Randomness flows through `workload.randoms` so Antithesis explores the mutation space and replays counterexamples deterministically.
+`submit_fuzzed(name, base, client, wallet)` applies 1–3 type-inferred mutations to a valid base's dict (boundary/zero/max, hostile hashes/accounts, empty/oversize/duplicate arrays, field drops), keeping it encodable and signed so it reaches preflight/preclaim/doApply. Leaves auth/sequence/fee intact (`_PROTECTED`). Rides `submit_raw`; emits `workload::fuzz` (+ `workload::fuzz_skipped`). Wired as one `"fuzz"` choice alongside curated mutations (share a `_*_base()` builder).
 
 ### LoanSet co-signing
-`LoanSet` requires dual signing (borrower + broker). Uses `autofill_and_sign` → `sign_loan_set_by_counterparty` → `xrpl_submit` directly (not `submit_tx`). Calls `tx_submitted("LoanSet", txn, response.result)` after submit so the submit-time tef* internal-error assertion fires on the engine result. See `lending.py:_loan_set_valid`. Setup-phase paths that submit directly (`setup.py` LoanSet co-sign and `_probe_node`) call `assert_no_internal_error_submit(name, resp.result)` instead — they emit their own `setup_*` events rather than the runtime `submitted` event.
-
-### XRPL specifications
-Transaction format docs are at `xrpl.org/docs/references/protocol/transactions/types/<name>`. Authoritative XLS specifications (especially for newer features like vaults and lending) live in `github.com/XRPLF/XRPL-Standards` under `XLS-NNNN-<name>/`.
+Dual sign (borrower + broker): `autofill_and_sign` → `sign_loan_set_by_counterparty` → `xrpl_submit`, then `tx_submitted("LoanSet", txn, result)`. Setup direct paths (`setup.py` co-sign, `_probe_node`) call `assert_no_internal_error_submit` and emit `setup_*` instead.
 
 ### Setup dependency chain
-Gateways → trust_lines → iou_distribution → mpt_issuances → mpt_auth → mpt_distribution → mpt_lock → vaults → vault_deposits → holder_vault_deposits → nfts → nft_offers → credentials → credential_accepts → tickets → domains → loan_brokers → cover_deposits → loans → zero_interest_loan_payoff. If gateways fail, almost everything downstream cascades. Setup accepts the credentials it issues (`credential_accepts`) so their subjects become permissioned-domain members — without acceptance `accountInDomain` fails and the permissioned-DEX valid paths starve.
+gateways → trust_lines → iou_distribution → mpt_issuances → mpt_auth → mpt_distribution → mpt_lock → vaults → vault_deposits → holder_vault_deposits → nfts → nft_offers → credentials → credential_accepts → tickets → domains → loan_brokers → cover_deposits → loans → zero_interest_loan_payoff. Gateway failure cascades. `credential_accepts` makes subjects domain members — without it `accountInDomain` fails and permissioned-DEX valid paths starve.
 
-MPT issuances are minted as flag-distinct **cohorts** (setup step 4), one issuer account each, so the XLS-82 MPT-on-DEX paths (`OfferCreateMPT`, `PaymentMPT`, and MPT-paired AMMs in `amm.py`) can reach both their valid and fault gates: `[0]/[1]` tradeable (`CanTrade|CanTransfer`, funded authorized holders → reliable success), `[2]` no-trade (`tecNO_PERMISSION`), `[3]` no-transfer (`tecNO_AUTH`/`tecPATH_PARTIAL`), `[4]` require-auth (issuer never authorizes → `tecNO_AUTH`), `[5]` lockable → locked in step `mpt_lock` (`tecLOCKED` on offers/AMM, `tecPATH_DRY` on MPTokensV2 payments). `MPTokenIssuance` tracks `can_trade/can_transfer/require_auth/locked/holders` (flags parsed in `_on_mpt_create`, holders in `_on_mpt_authorize`) so handlers select the right cohort. Because `_on_amm_create` now tracks MPT-paired AMMs, any consumer of `w.amms` must filter `isinstance(asset, IssuedCurrency)` (not `not isinstance(_, XRP)`) before reading `.currency`/`.issuer`, or it raises on an `MPTCurrency` leg.
+### MPT cohorts (XLS-82)
+Setup step 4 mints flag-distinct cohorts (one issuer each) so MPT-on-DEX paths hit valid + fault gates: `[0]/[1]` tradeable (success), `[2]` no-trade (`tecNO_PERMISSION`), `[3]` no-transfer (`tecNO_AUTH`/`tecPATH_PARTIAL`), `[4]` require-auth never authorized (`tecNO_AUTH`), `[5]` lockable→locked in `mpt_lock` (`tecLOCKED` / `tecPATH_DRY`). `MPTokenIssuance` tracks `can_trade/can_transfer/require_auth/locked/holders`. `w.amms` now holds MPT-paired AMMs — filter `isinstance(asset, IssuedCurrency)` before reading `.currency`/`.issuer`.
 
-### SequenceTracker
-`SequenceTracker` (`sequence.py`) prevents `tefPAST_SEQ` cascades in setup. Lazily fetches each account's sequence from the ledger on first use, then increments in-memory. All `_submit_batch` calls and LoanSet co-signing paths in setup use it. Driver endpoints still use xrpl-py autofill (no tracker needed for one-off calls). **Gotcha:** `TicketCreate` advances the account Sequence by `TicketCount + 1` (the only tx that increases Sequence by >1), but `next_seq` only counts +1 — so after a setup `TicketCreate` on an account reused by a later setup tx, call `seq.advance(addr, TicketCount)` (see the tickets step; domain owners 50-52 are both ticket holders and domain creators).
+### SequenceTracker (`sequence.py`)
+Prevents `tefPAST_SEQ` cascades in setup: lazy-fetch each account's sequence, then increment in-memory. Setup batches + LoanSet co-sign use it; drivers use autofill. Gotcha: `TicketCreate` advances Sequence by `count + 1` (only tx >1), but `next_seq` counts +1 — after a setup `TicketCreate` on a reused account call `seq.advance(addr, count)`.
 
-### Structured transaction events
-`tx_submitted()` emits `workload::submitted : {TxType}` and `tx_result()` emits `workload::result : {TxType}` via Antithesis `send_event`. Both include `account`, `sequence`, `tx_type`, and relevant object IDs (`vault_id`, `loan_id`, `nftoken_id`, etc.). Results also include `created_id`/`created_type` and `deleted_id`/`deleted_type` from metadata for object lifecycle tracking.
+### Structured events
+`tx_submitted()` → `workload::submitted : {TxType}`; `tx_result()` → `workload::result : {TxType}`. Both carry account/sequence/tx_type + object IDs; results add `created_id`/`created_type`, `deleted_id`/`deleted_type`. Inner batch txns (`tfInnerBatchTxn`) also emit `workload::inner_batch_observed`; normal `tx_result()` still runs.
 
-Inner batch transactions (top-level entries with `tfInnerBatchTxn` set, applied by rippled as side effects of an outer Batch) are tagged by `ws_listener.py` with a dedicated `workload::inner_batch_observed` event for grep-ability. Normal `tx_result()` processing still runs so state updaters can track inner-txn side effects (minted NFTs, created credentials, etc.).
+### Synthetic assertion names
+Some `REGISTRY` entries use a synthetic `name` ≠ on-ledger `TransactionType` for dedicated buckets: `OfferCreateDomain`, `OfferCreateHybrid`, `PaymentDomain`, `PaymentDomainXC` (`permissioned_dex.py`), `OfferCreateMPT`, `PaymentMPT` (`mpt_dex.py`) — all submit as `OfferCreate`/`Payment`. Handlers pass the synthetic name to `submit_tx`; `ws_listener.py` maps the validated tx back: `DomainID` present (+ `tfHybrid`/cross-currency), MPT leg via `_amount_is_mpt`. STATE_UPDATERS stay keyed by real type → these use `None`. Synthetic names whose `sometimes(success)` can't be reliably hit (`PaymentDomainXC`) go in `assertions._NO_SUCCESS_TYPES`; `OfferCreateMPT`/`PaymentMPT` don't (their valid paths rest reliably).
 
-### Synthetic assertion names (permissioned DEX, MPT-on-DEX & TicketUse)
-Some REGISTRY entries use a synthetic `name` that differs from the on-ledger `TransactionType`, to get dedicated `seen`/`success`/`failure` buckets for a variant of an existing transaction. Permissioned-DEX handlers (`transactions/permissioned_dex.py`) register `OfferCreateDomain`, `OfferCreateHybrid`, `PaymentDomain`, `PaymentDomainXC` — all submit as `OfferCreate`/`Payment` on-ledger. The MPT-on-DEX handler (`transactions/mpt_dex.py`) registers `OfferCreateMPT` — an `OfferCreate` with an MPT leg — and `PaymentMPT` — a `Payment` carrying an MPT. The submit side already uses the synthetic name (handlers pass it to `submit_tx`). The result side must be taught the mapping in `ws_listener.py`: it fires `tx_result(<synthetic>, ...)` when a validated `OfferCreate`/`Payment` carries a `DomainID` (and `tfHybrid` / cross-currency distinguish the sub-variants), (independently) `tx_result("OfferCreateMPT", ...)` when a validated `OfferCreate` carries an MPT leg (`_amount_is_mpt(TakerGets|TakerPays)`), and (independently) `tx_result("PaymentMPT", ...)` when a validated `Payment` carries an MPT leg (`_amount_is_mpt(DeliverMax|SendMax)` — this also catches the generic `Payment` handler's MPT sends, intentionally). This mirrors the existing `TicketUse` mapping. STATE_UPDATERS lookup stays keyed by the real `TransactionType`, so these entries use `None` for their updater (the real-type updater, e.g. `_on_offer_create`, handles state; `Payment` has no updater). A synthetic name whose `sometimes(success)` cannot be reliably hit (e.g. `PaymentDomainXC`, which needs resting domain liquidity) goes in `assertions._NO_SUCCESS_TYPES`; `OfferCreateMPT` is NOT in that set because its buy-MPT-for-XRP valid path rests in an empty book → reliable tesSUCCESS, and `PaymentMPT` is NOT in that set because its direct holder→holder transfer of a tradeable MPT → reliable tesSUCCESS (the cross-token best-effort variant, which usually ends tecPATH_DRY, is a minority of the valid path).
+**api_version 2 gotcha:** the WS stream renames a Payment's `Amount` to `DeliverMax` and drops `Amount`. Read delivered amount via `_delivered_amount(tx)` (`DeliverMax`, `Amount` fallback) — `tx["Amount"]` is `None` and misclassifies. `DomainID`/`SendMax`/`TakerGets`/`TakerPays` are unaffected.
 
-**api_version 2 gotcha (Payment classification):** the WS stream is api_version 2, where rippled renames a Payment's `Amount` field to `DeliverMax` and DROPS `Amount` (see rippled `insertDeliverMax`). So any `ws_listener` logic inspecting a validated *Payment's* delivered amount MUST read `DeliverMax` (with an `Amount` fallback) via `_delivered_amount(tx)` — reading `tx["Amount"]` yields `None` and silently misclassifies. This is what made `PaymentDomain` (direct) and direct-MPT `PaymentMPT` map as their cross-currency siblings / not at all; `DomainID`/`SendMax`/`TakerGets`/`TakerPays` are unaffected by the rename.
+`permissioned_dex._domain_members` = owner + holders of an accepted matching credential; needs `PermissionedDomain.accepted_credentials` and `Credential.accepted` tracked.
 
-Domain membership is computed dynamically: `permissioned_dex._domain_members` = domain owner + holders of an *accepted* credential matching the domain's `accepted_credentials`. This requires `PermissionedDomain.accepted_credentials` (parsed in `_on_domain_set`) and `Credential.accepted` (flipped by `_on_credential_accept`) to be tracked.
+### Logging
+No logger calls in `setup.py` or handlers — `send_event` + assertions cover observability. `setup.py` emits `workload::setup_reject : {phase}` / `setup_error : {phase}`. Only `ws_listener.py` keeps warn/error logs; `sequence.py` one debug log.
 
-### Logging policy
-No logger calls in setup.py or transaction handlers — structured `send_event` calls and assertions cover observability. `setup.py` emits `workload::setup_reject : {phase}` on non-success engine results and `workload::setup_error : {phase}` on exceptions. Only `ws_listener.py` retains warning/error logs for connection issues and state update failures. `sequence.py` has one debug log for tracker initialization.
-
-### Randomness
-All randomness goes through `workload.randoms` (backed by `AntithesisRandom`). Parameter generators live in `params.py` — never hardcode values in transaction builders.
+### Randomness & specs
+All randomness via `workload.randoms` (`AntithesisRandom`); generators in `params.py`, never hardcode. Tx docs: `xrpl.org/docs/references/protocol/transactions/types/<name>`; specs: `github.com/XRPLF/XRPL-Standards` `XLS-NNNN-<name>/`.
+</content>
+</invoke>

--- a/workload/src/workload/app.py
+++ b/workload/src/workload/app.py
@@ -46,8 +46,7 @@ class Workload:
         self.checks = []
         self.payment_channels = []
         self.offers: list[dict] = []
-        # Addresses used by setup (gateways, vault creators, etc.) — never delete these.
-        # Populated by run_setup().
+        # Setup addresses (gateways, vault creators, etc.) — never delete; populated by run_setup().
         self.protected_accounts: set[str] = set()
         self.deleted_vault_ids: list[str] = []
         self.deleted_broker_ids: list[str] = []
@@ -104,10 +103,7 @@ class Workload:
         logger.info("Workload initialized after %ss", int(time.time() - self.start_time))
 
     def load_initial_accounts(self, accounts_json: Path) -> None:
-        """Load pre-generated accounts from a JSON file.
-
-        Expects format: [{"address": "r...", "seed": "s..."}, ...]
-        """
+        """Load pre-generated accounts from JSON: [{"address": "r...", "seed": "s..."}, ...]."""
         logger.info(f"Loading accounts from {accounts_json}")
         accounts = json.loads(accounts_json.read_text())
         default_algo = CryptoAlgorithm[
@@ -119,12 +115,7 @@ class Workload:
         logger.info(f"Loaded {len(self.accounts)} accounts")
 
     def wait_for_network(self, xrpld: str) -> None:
-        """Wait for xrpld to be stably synced (multiple consecutive checks).
-
-        A single 'full' response can be a transient moment during validator
-        convergence. Requiring consecutive successes ensures the snapshot
-        taken after setup_complete() captures a stable network state.
-        """
+        """Require consecutive sync checks — a single 'full' can be transient during convergence."""
         timeout = self.config["xrpld"]["timeout"]
         wait_start = time.time()
         required_consecutive = 3
@@ -146,8 +137,6 @@ class Workload:
 
 
 def _make_endpoint(path: str, name: str, handler_fn: Callable, args_fn: Callable) -> Callable:
-    """Create an endpoint handler with standardized error handling."""
-
     async def endpoint(w: Workload = Depends(get_workload)):
         try:
             return await handler_fn(*args_fn(w))
@@ -198,7 +187,7 @@ def create_app(workload: Workload) -> FastAPI:
 
         lifecycle.setup_complete(details={"message": "Setup complete, faults may begin"})
         ready["value"] = True
-        yield  # app runs here, shutdown after yield
+        yield
 
         ws_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -215,7 +204,6 @@ def create_app(workload: Workload) -> FastAPI:
     def get_workload():
         return workload
 
-    # Register all transaction endpoints from the registry
     for name, path, handler_fn, args_fn, _ in REGISTRY:
         app.get(path)(_make_endpoint(path, name, handler_fn, args_fn))
 

--- a/workload/src/workload/assertions.py
+++ b/workload/src/workload/assertions.py
@@ -1,13 +1,4 @@
-"""Antithesis assertion helpers for the workload.
-
-Follows the fuzzer's naming convention:
-  "workload::seen : TxType"    — transaction was created and submitted (reachable)
-  "workload::success : TxType" — transaction got tesSUCCESS (sometimes)
-
-Uses assert_raw() to register catalog entries at startup and emit assertions
-at runtime. The static scanner cannot extract assertion names from f-strings,
-so we pre-register all known transaction types via register_assertions().
-"""
+"""Antithesis assertion helpers for the workload."""
 
 from antithesis.assertions import assert_raw
 from antithesis.lifecycle import send_event
@@ -16,13 +7,10 @@ _LOC_FILE = "workload/assertions.py"
 _LOC_CLASS = ""
 _LOC_COL = 0
 
-# Engine results that indicate a rippled internal error (exception caught,
-# invariant violated, etc.). Checked on BOTH the submit response and the
-# validated WS stream:
-#   - tef* never validates; the submit-time check catches those.
-#   - tecINVARIANT_FAILED claims a fee and DOES validate (rippled returns it on
-#     the first invariant failure, escalating to tefINVARIANT_FAILED only if the
-#     fee-only retry also fails) — so the validated-side check catches it.
+# Engine results signalling a rippled internal error. Checked on BOTH submit
+# and validated WS: tef* never validates (submit-side catches it); but
+# tecINVARIANT_FAILED claims a fee and DOES validate, so the validated side
+# must catch that one.
 _RIPPLED_INTERNAL_ERRORS = (
     "tefEXCEPTION",
     "tefINTERNAL",
@@ -31,38 +19,32 @@ _RIPPLED_INTERNAL_ERRORS = (
     "tecINVARIANT_FAILED",
 )
 
-# Types whose current faulty handler never produces a non-tesSUCCESS engine
-# result, so the failure assertion can't be met.
-# - SignerListSet: fake AccountIDs are accepted (rippled doesn't verify
-#   listed accounts exist); current mutations stay within weight bounds.
-# - MPTokenIssuanceCreate: no _faulty handler — always submits a valid create.
+# Types whose faulty handler never produces a non-tesSUCCESS, so failure can't
+# be met:
+# - SignerListSet: fake AccountIDs accepted (rippled doesn't verify listed
+#   accounts exist); mutations stay within weight bounds.
+# - MPTokenIssuanceCreate: no _faulty handler — always a valid create.
 _NO_FAILURE_TYPES = {
     "SignerListSet",
     "MPTokenIssuanceCreate",
 }
 
-# Types that effectively never succeed in this test environment.
-# - AccountDelete: every account owns directory objects (trust lines, NFTs,
-#   etc.), so rippled rejects with tecHAS_OBLIGATIONS.
-# - AMMDelete: rippled auto-deletes empty AMMs as a side effect of the last
-#   LP's TF_WITHDRAW_ALL, so AMMDelete usually finds the AMM already gone
-#   (tecAMM_NOT_FOUND) or with outstanding LP tokens (tecAMM_NOT_EMPTY).
-# - PaymentDomainXC: cross-currency domain payment success needs resting domain
-#   liquidity in the matching direction, which the workload does not guarantee;
-#   it reliably exercises the both-in-domain preclaim + domain pathfinding but
-#   usually ends tecPATH_DRY. Drop from this set if runs show success is hit.
+# Types that effectively never succeed in this test environment:
+# - AccountDelete: every account owns directory objects → tecHAS_OBLIGATIONS.
+# - AMMDelete: rippled auto-deletes empty AMMs on the last LP's TF_WITHDRAW_ALL,
+#   so it finds the AMM gone (tecAMM_NOT_FOUND) or non-empty (tecAMM_NOT_EMPTY).
+# - PaymentDomainXC: cross-currency domain payment needs resting domain
+#   liquidity the workload doesn't guarantee; usually tecPATH_DRY. Drop if hit.
 _NO_SUCCESS_TYPES = {"AccountDelete", "AMMDelete", "PaymentDomainXC"}
 
-# Metadata expectations for tx types that must create/modify/delete specific
-# ledger entry types on tesSUCCESS.  Each value is a tuple of allowed node
-# operations followed by the expected LedgerEntryType.  Checked inside
-# tx_result() with a single shared assertion ID.
+# tx types that must touch a specific ledger entry on tesSUCCESS.
+# Value: allowed node ops followed by the expected LedgerEntryType.
 _META_EXPECTATIONS: dict[str, tuple[str, ...]] = {
     "DIDSet": ("Created", "Modified", "DID"),
     "DIDDelete": ("Deleted", "DID"),
 }
 
-# XRPL fields → normalized event keys. Only object identifiers needed for tracking.
+# XRPL fields → normalized event keys; only object identifiers, for tracking.
 _OBJECT_ID_FIELDS: dict[str, str] = {
     "Destination": "destination",
     "VaultID": "vault_id",
@@ -89,7 +71,6 @@ def _failure_id(name: str) -> str:
 
 
 def _extract_object_ids(raw: dict) -> dict[str, str]:
-    """Extract known object ID fields from a transaction dict."""
     ids: dict[str, str] = {}
     for xrpl_key, event_key in _OBJECT_ID_FIELDS.items():
         if xrpl_key in raw:
@@ -98,7 +79,7 @@ def _extract_object_ids(raw: dict) -> dict[str, str]:
 
 
 def _emit_catalog_entry(message: str, assert_type: str, display_type: str, must_hit: bool) -> None:
-    """Register a single catalog entry (hit=False) so Antithesis knows this assertion exists."""
+    """hit=False registers existence with Antithesis without claiming a hit."""
     assert_raw(
         condition=True,
         message=message,
@@ -117,10 +98,7 @@ def _emit_catalog_entry(message: str, assert_type: str, display_type: str, must_
 
 
 def register_assertions() -> None:
-    """Register catalog entries for all known transaction types.
-
-    Call once at app startup before any transactions are submitted.
-    """
+    """Call once at startup, before any transactions are submitted."""
     from workload.transactions import TX_TYPES
 
     for name in TX_TYPES:
@@ -173,13 +151,8 @@ def register_assertions() -> None:
 
 
 def assert_no_internal_error_submit(name: str, result: dict) -> None:
-    """Fire the no_internal_rippled_error_submit always-assertion for a submit result.
-
-    Use from any path that submits directly via xrpl-py (bypassing ``submit_tx``)
-    — e.g. setup-phase LoanSet co-signing and the node probe. Submit-time is
-    where tef* internal errors must be caught: they never enter a closed ledger
-    and so never reach the validated WS stream that ``tx_result`` consumes.
-    """
+    """For direct xrpl-py submits (bypassing submit_tx): tef* internal errors
+    never enter a closed ledger, so only the submit side can catch them."""
     engine_result = result.get("engine_result", "") or ""
     if not engine_result:
         return
@@ -206,17 +179,12 @@ def assert_no_internal_error_submit(name: str, result: dict) -> None:
 
 
 def tx_submitted(name: str, txn: object = None, result: dict | None = None) -> None:
-    """Report that a transaction was submitted to the network.
-
-    ``result`` is the immediate /submit response dict. Passing it here
-    surfaces ``engine_result`` in the event details and triggers the
-    submit-time tef* internal-error always-assertion.
-    """
+    """Passing the /submit response triggers the submit-time tef* check."""
     details: dict[str, str] = {"tx_type": name}
     if txn is not None:
         try:
-            # Accept either an xrpl-py model or an already-serialized XRPL dict
-            # (the raw-submit path in submit.py passes the mutated dict directly).
+            # Accept an xrpl-py model or an already-serialized dict (raw-submit
+            # path passes the mutated dict directly).
             raw = txn.to_xrpl() if hasattr(txn, "to_xrpl") else txn
             details["account"] = raw.get("Account", "")
             details["sequence"] = str(raw.get("Sequence", ""))
@@ -254,7 +222,6 @@ def tx_submitted(name: str, txn: object = None, result: dict | None = None) -> N
 
 
 def tx_result(name: str, result: dict) -> None:
-    """Report a validated transaction result to Antithesis."""
     tx_json = result.get("tx_json", {})
     meta = result.get("meta", {})
     engine_result = result.get("engine_result") or meta.get("TransactionResult") or "unknown"
@@ -363,7 +330,7 @@ def tx_result(name: str, result: dict) -> None:
         display_type="Sometimes",
         assert_id=_failure_id(name),
     )
-    # Meta-invariant: on tesSUCCESS, verify expected ledger entry operations.
+    # On tesSUCCESS, verify the expected ledger entry operations.
     exp = _META_EXPECTATIONS.get(name)
     if exp and engine_result == "tesSUCCESS":
         *ops, entry_type = exp

--- a/workload/src/workload/fuzz.py
+++ b/workload/src/workload/fuzz.py
@@ -1,24 +1,4 @@
-"""Generative, schema-agnostic mutation for ``_faulty`` transaction paths.
-
-True fuzzing for the faulty path: instead of a fixed menu of predicted faults,
-take a VALID transaction dict and apply random, open-ended mutations that keep
-it encodable and validly signed — so it reaches rippled's preflight / preclaim /
-doApply (where bugs live), not just the binary parser.
-
-Used via ``submit_fuzzed()`` from ``_faulty`` handlers, ALONGSIDE the curated
-mutations (curated guarantees named TER-code coverage and encodes known-bug
-knowledge; this finds the unknown-unknowns). Auth / sequence / fee fields are
-left intact so the transaction authenticates and gets past the cheap rejects.
-
-All randomness flows through ``workload.randoms`` so Antithesis explores the
-mutation space, and every fuzzed submission emits a ``workload::fuzz`` event
-recording the exact operators applied for reproducible triage.
-
-Boundary: fuzz only mutates or drops EXISTING fields, never adds new ones.
-New-sfield injection and type-confusion-via-unknown-field are out of scope by
-design — adding fields the model didn't emit would break encoding, and keeping
-the blob encodable (so it reaches the transactor) is the whole point.
-"""
+"""Generative mutation for ``_faulty`` paths: corrupt a valid tx dict, kept encodable+signed."""
 
 from __future__ import annotations
 
@@ -32,8 +12,8 @@ from workload import params
 from workload.randoms import choice, randint, random
 from workload.submit import submit_raw
 
-# Fields left intact: mutating these yields shallow auth / sequence / fee
-# rejects instead of reaching the transactor logic we want to fuzz.
+# Left intact: mutating these yields shallow auth/sequence/fee rejects instead
+# of reaching the transactor logic we want to fuzz.
 _PROTECTED = {
     "TransactionType",
     "Account",
@@ -105,11 +85,8 @@ async def submit_fuzzed(
     client: AsyncJsonRpcClient,
     wallet: Wallet,
 ) -> dict | None:
-    """Apply ``fuzz_mutate`` to a valid ``base`` and submit via the raw path.
-
-    Emits ``workload::fuzz`` with the operators applied + engine_result. If a
-    hostile shape can't be serialized, emits ``workload::fuzz_skipped`` and
-    returns None — never raises (faulty paths must not).
+    """Fuzz a valid ``base`` and submit raw. Never raises (faulty paths must not):
+    an unserializable shape emits ``workload::fuzz_skipped`` and returns None.
     """
     ops: list[str] = []
 

--- a/workload/src/workload/models.py
+++ b/workload/src/workload/models.py
@@ -67,8 +67,6 @@ class UserAccount(Account):
 
 @dataclass
 class Delegate:
-    """A delegation relationship: source granted delegate_address permission."""
-
     source: str
     delegate_address: str
     permissions: list[str]  # TransactionType values e.g. ["Payment", "TrustSet"]
@@ -76,7 +74,7 @@ class Delegate:
 
 @dataclass
 class DID:
-    """A DID ledger entry attached to an account (XLS-72)."""
+    """DID ledger entry attached to an account (XLS-72)."""
 
     account: str
 
@@ -109,9 +107,7 @@ class Vault:
 class PermissionedDomain:
     owner: str
     domain_id: str
-    # Accepted credentials as (issuer, credential_type) pairs. An account is a
-    # domain member if it is the owner or holds an accepted credential matching
-    # one of these pairs (see permissioned_dex._domain_members).
+    # (issuer, credential_type) pairs; member = owner or holder of a matching accepted credential.
     accepted_credentials: list[tuple[str, str]] = field(default_factory=list)
 
 
@@ -153,8 +149,6 @@ class Loan:
 
 @dataclass
 class Escrow:
-    """An active escrow on the ledger."""
-
     owner: str
     destination: str
     sequence: int
@@ -166,8 +160,6 @@ class Escrow:
 
 @dataclass
 class Check:
-    """An active check on the ledger."""
-
     check_id: str
     creator: str
     destination: str
@@ -176,8 +168,6 @@ class Check:
 
 @dataclass
 class PaymentChannel:
-    """An active payment channel on the ledger."""
-
     channel_id: str
     source: str
     destination: str

--- a/workload/src/workload/params.py
+++ b/workload/src/workload/params.py
@@ -1,50 +1,35 @@
-"""Centralized random parameter generators for workload transactions.
-
-Every tunable transaction parameter lives here. Call these functions
-at the point of use — never cache the return value.
-"""
+"""Centralized random parameter generators; call at point of use, never cache."""
 
 from workload.randoms import choice, randint, random
 
 
 # ── Fuzzing ──────────────────────────────────────────────────────────
 def should_send_faulty() -> bool:
-    """Let Antithesis decide whether to bypass precondition checks
-    and send a deliberately invalid transaction."""
     return random() < 0.01
 
 
 def fake_account() -> str:
-    """Generate a valid-format but non-existent XRPL account address."""
     from xrpl.wallet import Wallet
 
     return Wallet.create().address
 
 
 def fake_id() -> str:
-    """Generate a random 64-char hex string (fake object ID)."""
     return bytes(randint(0, 255) for _ in range(32)).hex().upper()
 
 
 def fake_mpt_id() -> str:
-    """Generate a valid-format but nonexistent MPTokenIssuanceID.
-
-    An MPTokenIssuanceID is 192-bit (24 bytes = 48 hex chars): a 4-byte
-    sequence concatenated with the 20-byte issuer account. Distinct from
-    ``fake_id()``, which returns 64-hex (256-bit) object/ledger-entry IDs.
-    """
+    """MPTokenIssuanceID is 24 bytes (4-byte seq + 20-byte issuer), unlike fake_id's 32."""
     return bytes(randint(0, 255) for _ in range(24)).hex().upper()
 
 
 # ── Fees ─────────────────────────────────────────────────────────────
 def fee() -> str:
-    """Transaction fee in drops."""
     return str(randint(10, 100))
 
 
 # ── Payments ─────────────────────────────────────────────────────────
 def payment_amount() -> str:
-    """Payment amount in drops."""
     return str(randint(1_000, 10_000_000))
 
 
@@ -53,34 +38,28 @@ CURRENCY_CODES = ["USD", "EUR", "GBP", "JPY", "BTC", "ETH", "XAU", "CNY"]
 
 
 def currency_code() -> str:
-    """Random 3-letter currency code."""
     return choice(CURRENCY_CODES)
 
 
 def trustline_limit() -> str:
-    """Trust line limit value. Ranges from 0 to 100k to overlap with
-    typical IOU payment amounts (1-10k), ensuring we hit limit violations."""
+    """Range overlaps IOU amounts (1-10k) to hit limit violations."""
     return str(randint(0, 100_000))
 
 
 def iou_amount() -> str:
-    """IOU payment amount (value, not drops)."""
     return str(randint(1, 10_000))
 
 
 # ── Offers / DEX ─────────────────────────────────────────────────────
 def offer_xrp_drops() -> str:
-    """XRP amount in drops for a DEX offer leg (0.1-10 XRP)."""
     return str(randint(100_000, 10_000_000))
 
 
 def offer_iou_value() -> str:
-    """IOU value for a DEX offer leg."""
     return str(randint(1, 50))
 
 
 def mpt_offer_value() -> str:
-    """Small MPT amount for a DEX offer leg (MPT value is an integer string)."""
     return str(randint(1, 1000))
 
 
@@ -90,106 +69,94 @@ def nft_taxon() -> int:
 
 
 def nft_transfer_fee() -> int:
-    """Transfer fee in 1/10th basis points (0-50000 = 0-50%)."""
+    """1/10th basis points (0-50000 = 0-50%)."""
     return randint(0, 50000)
 
 
 def nft_memo() -> str:
-    """Human-readable memo string (not yet hex-encoded)."""
     return f"nft-memo-{randint(0, 1_000_000)}"
 
 
 def nft_offer_amount() -> str:
-    """Amount in drops for NFToken offers."""
     return str(randint(1_000, 10_000_000))
 
 
 # ── Tickets ──────────────────────────────────────────────────────────
 def ticket_count() -> int:
-    """1-250 tickets per TicketCreate."""
+    """1-250 per TicketCreate."""
     return randint(1, 250)
 
 
 # ── Batch ────────────────────────────────────────────────────────────
 def batch_size() -> int:
-    """Number of inner transactions in a batch (min 2 per xrpl-py, max 8 per rippled)."""
+    """Min 2 per xrpl-py, max 8 per rippled."""
     return randint(2, 8)
 
 
 def batch_inner_amount() -> str:
-    """Amount for each inner batch transaction in drops."""
     return str(randint(1_000, 10_000_000))
 
 
 # ── Credentials ──────────────────────────────────────────────────────
 def credential_type() -> str:
-    """Random hex-encoded credential type (1-64 bytes → 2-128 hex chars)."""
+    """1-64 bytes per spec."""
     length = randint(1, 64)
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
 def credential_uri() -> str:
-    """Random hex-encoded URI for credentials (max 256 hex chars = 128 bytes)."""
+    """Max 128 bytes per spec."""
     length = randint(5, 128)
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
 def credential_expiration_offset() -> int:
-    """Seconds from now until credential expires."""
     return randint(3600, 86400 * 30)  # 1 hour to 30 days
 
 
 # ── Vaults ───────────────────────────────────────────────────────────
 def vault_deposit_amount() -> str:
-    """Deposit amount in drops for vaults."""
     return str(randint(1_000_000, 100_000_000))
 
 
 def vault_withdraw_amount() -> str:
-    """Withdraw amount in drops for vaults."""
     return str(randint(100_000, 50_000_000))
 
 
 def vault_data() -> str:
-    """Random hex-encoded vault metadata (up to 256 bytes → 512 hex chars)."""
+    """Max 256 bytes per spec."""
     length = randint(1, 256)
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
 def vault_assets_maximum() -> str:
-    """Maximum vault capacity in drops."""
     return str(randint(100_000_000, 10_000_000_000))
 
 
 # ── Permissioned Domains ─────────────────────────────────────────────
 def domain_credential_count() -> int:
-    """Number of accepted credentials in a permissioned domain (1-10)."""
+    """1-10 accepted credentials per domain."""
     return randint(1, 10)
 
 
 def zero_domain_id() -> str:
-    """All-zero 64-char DomainID. Malformed per rippled — preflight temMALFORMED
-    when fixCleanup3_2_0 is enabled, otherwise exercises the zero-key domain read
-    / accountInDomain zero-guard. xrpl-py accepts it (64 hex chars)."""
+    """All-zero DomainID: temMALFORMED under fixCleanup3_2_0; xrpl-py accepts it."""
     return "0" * 64
 
 
 def should_update_domain() -> bool:
-    """Whether PermissionedDomainSet updates an existing domain (modify path)
-    rather than creating a new one."""
     return random() < 0.3
 
 
 # ── NFToken Modify ───────────────────────────────────────────────────
 def nft_uri() -> str:
-    """Random hex-encoded URI for NFTs (max 512 hex chars = 256 bytes)."""
+    """Max 256 bytes per spec."""
     length = randint(5, 256)
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
 # ── MPToken ──────────────────────────────────────────────────────────
 def mpt_amount() -> str:
-    """MPT payment/transfer amount."""
     return str(randint(1, 10_000))
 
 
@@ -199,65 +166,59 @@ def mpt_maximum_amount() -> str:
 
 
 def mpt_metadata() -> str:
-    """Random hex-encoded MPToken metadata (max 1024 bytes)."""
+    """Max 1024 bytes per spec."""
     length = randint(1, 1024)
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
 # ── AMM ─────────────────────────────────────────────────────────────
 def amm_trading_fee() -> int:
-    """Trading fee in 1/100,000th (0-1000 = 0-1%)."""
+    """1/100,000th (0-1000 = 0-1%)."""
     return randint(0, 1000)
 
 
 def amm_deposit_amount() -> str:
-    """AMM deposit amount for IOU tokens (within typical 10k balance)."""
+    """Within typical 10k balance."""
     return str(randint(100, 5_000))
 
 
 def amm_withdraw_amount() -> str:
-    """AMM withdrawal amount for IOU tokens."""
     return str(randint(100, 50_000))
 
 
 def amm_lp_token_amount() -> str:
-    """LP token amount for deposits/withdrawals/bids."""
     return str(randint(1, 10_000))
 
 
 def amm_bid_min() -> str:
-    """Minimum bid price for auction slot."""
     return str(randint(1, 1_000))
 
 
 def amm_bid_max() -> str:
-    """Maximum bid price for auction slot."""
     return str(randint(1_000, 10_000))
 
 
 def amm_vote_fee() -> int:
-    """Fee value for AMM vote (0-1000)."""
     return randint(0, 1000)
 
 
 def amm_xrp_amount() -> str:
-    """XRP amount in drops for AMM pools."""
     return str(randint(10_000_000, 1_000_000_000))
 
 
 # ── Lending Protocol ─────────────────────────────────────────────────
 def loan_broker_management_fee_rate() -> int:
-    """1/10th basis point fee (0-10000 = 0-10%)."""
+    """1/10th basis point (0-10000 = 0-10%)."""
     return randint(0, 10000)
 
 
 def loan_broker_cover_rate_minimum() -> int:
-    """1/10th basis point cover rate (0-100000 = 0-100%)."""
+    """1/10th basis point (0-100000 = 0-100%)."""
     return randint(0, 100000)
 
 
 def loan_broker_cover_rate_liquidation() -> int:
-    """1/10th basis point liquidation rate (0-100000 = 0-100%)."""
+    """1/10th basis point (0-100000 = 0-100%)."""
     return randint(0, 100000)
 
 
@@ -266,43 +227,39 @@ def loan_broker_debt_maximum() -> str:
 
 
 def loan_broker_data() -> str:
-    """Random hex-encoded broker metadata (max 256 bytes)."""
+    """Max 256 bytes per spec."""
     length = randint(1, 256)
     return bytes(randint(0, 255) for _ in range(length)).hex()
 
 
 def loan_principal() -> str:
-    """Loan principal amount in drops."""
     return str(randint(100_000, 50_000_000))
 
 
 def loan_interest_rate() -> int:
-    """Annualized interest rate in 1/10th basis points (0-100000 = 0-100%)."""
+    """1/10th basis points (0-100000 = 0-100%)."""
     return randint(0, 100000)
 
 
 def loan_payment_total() -> int:
-    """Total number of loan payments."""
     return randint(1, 24)
 
 
 def loan_payment_interval() -> int:
-    """Seconds between payments (min 60)."""
+    """Min 60."""
     return randint(60, 86400)
 
 
 def loan_grace_period(payment_interval: int) -> int:
-    """Seconds after due date before default (min 60, max ≤ payment_interval)."""
+    """Min 60, max ≤ payment_interval."""
     return randint(60, max(60, payment_interval))
 
 
 def loan_cover_deposit_amount() -> str:
-    """First loss capital deposit in drops."""
     return str(randint(100_000, 10_000_000))
 
 
 def loan_pay_amount() -> str:
-    """Loan payment amount in drops."""
     return str(randint(10_000, 5_000_000))
 
 
@@ -311,7 +268,6 @@ RIPPLE_EPOCH_OFFSET = 946_684_800
 
 
 def escrow_amount() -> str:
-    """Escrow amount in drops (0.1-50 XRP)."""
     return str(randint(100_000, 50_000_000))
 
 
@@ -322,26 +278,19 @@ def _ripple_now() -> int:
 
 
 def escrow_finish_after() -> int:
-    """Ripple timestamp a short time in the future (1-120s)."""
     return _ripple_now() + randint(1, 120)
 
 
 def escrow_cancel_after(finish_after: int) -> int:
-    """Ripple timestamp after finish_after (3-600s later)."""
     return finish_after + randint(3, 600)
 
 
 def escrow_condition_pair() -> tuple[str, str]:
-    """Generate a PREIMAGE-SHA-256 crypto-condition (condition, fulfillment) pair.
-
-    Returns (condition_hex, fulfillment_hex) where both are uppercased hex strings.
-    """
+    """PREIMAGE-SHA-256 (condition_hex, fulfillment_hex), both uppercased."""
     import hashlib
 
     preimage = bytes(randint(0, 255) for _ in range(32))
-    # Fulfillment: DER-encoded PREIMAGE-SHA-256
     fulfillment_bytes = bytes([0xA0, len(preimage) + 2, 0x80, len(preimage)]) + preimage
-    # Condition: type 0 (preimage), SHA-256 fingerprint, max fulfillment length
     fingerprint = hashlib.sha256(preimage).digest()
     condition_bytes = (
         bytes([0xA0, 0x25, 0x80, 0x20]) + fingerprint + bytes([0x81, 0x01, len(preimage)])
@@ -353,12 +302,11 @@ def escrow_condition_pair() -> tuple[str, str]:
 
 
 def check_send_max() -> str:
-    """Check send_max in drops (1-100 XRP)."""
     return str(randint(1_000_000, 100_000_000))
 
 
 def check_cash_amount(send_max: str) -> str:
-    """Cash amount ≤ send_max."""
+    """≤ send_max."""
     max_val = int(send_max)
     return str(randint(1, max_val))
 
@@ -367,22 +315,19 @@ def check_cash_amount(send_max: str) -> str:
 
 
 def channel_amount() -> str:
-    """Payment channel amount in drops (1-100 XRP)."""
     return str(randint(1_000_000, 100_000_000))
 
 
 def channel_settle_delay() -> int:
-    """Settle delay in seconds (60-3600)."""
     return randint(60, 3600)
 
 
 def channel_fund_amount() -> str:
-    """Additional XRP to add to a channel in drops (0.1-10 XRP)."""
     return str(randint(100_000, 10_000_000))
 
 
 def channel_claim_balance(channel_amount: str) -> str:
-    """Claim balance ≤ channel amount."""
+    """≤ channel amount."""
     max_val = int(channel_amount)
     return str(randint(1, max_val))
 
@@ -391,12 +336,12 @@ def channel_claim_balance(channel_amount: str) -> str:
 
 
 def clawback_iou_amount() -> str:
-    """IOU clawback value (1-1000, within typical 10k holder balance)."""
+    """Within typical 10k holder balance."""
     return str(randint(1, 1_000))
 
 
 def clawback_mpt_amount() -> str:
-    """MPT clawback value (1-1000, within typical 10k holder balance)."""
+    """Within typical 10k holder balance."""
     return str(randint(1, 1_000))
 
 
@@ -406,16 +351,12 @@ _HEX_CHARS = "0123456789ABCDEF"
 
 
 def did_hex_field() -> str:
-    """Random even-length hex string, max 256 hex chars (128 bytes).
-
-    Used for DID ``uri``, ``data``, and ``did_document`` fields.
-    """
+    """Even-length hex, max 128 bytes; for DID uri/data/did_document."""
     r = random()
     if r < 0.80:
         n = randint(1, 32)
     elif r < 0.95:
         n = randint(33, 100)
     else:
-        n = randint(101, 128)  # near the 256-hex-char / 128-byte limit
-    # n is number of BYTES; each byte = 2 hex chars → always even length
+        n = randint(101, 128)  # near the 128-byte limit
     return "".join(choice(_HEX_CHARS) for _ in range(n * 2))

--- a/workload/src/workload/sequence.py
+++ b/workload/src/workload/sequence.py
@@ -1,9 +1,4 @@
-"""Per-account sequence tracker for fire-and-forget transaction submission.
-
-Prevents tefPAST_SEQ cascades when multiple transactions from the same account
-are submitted before the ledger closes. Lazily fetches the starting sequence
-from the ledger, then increments in-memory for subsequent calls.
-"""
+"""Per-account sequence tracker; prevents tefPAST_SEQ cascades in fire-and-forget submission."""
 
 from __future__ import annotations
 
@@ -23,11 +18,7 @@ class SequenceTracker:
         self._seqs: dict[str, int] = {}
 
     async def next_seq(self, address: str) -> int:
-        """Return the next sequence for this account and advance the counter.
-
-        First call per account fetches from the ledger via RPC.
-        Subsequent calls return the in-memory counter (no RPC).
-        """
+        """Return the next sequence and advance; first call per account hits RPC."""
         if address not in self._seqs:
             seq = await get_next_valid_seq_number(address, self._client)
             self._seqs[address] = seq
@@ -37,13 +28,9 @@ class SequenceTracker:
         return seq
 
     def advance(self, address: str, by: int) -> None:
-        """Bump the tracked sequence by an extra ``by`` (no-op if untracked).
-
-        Needed for TicketCreate: it advances the account root Sequence by
-        ``TicketCount + 1`` (it is the only transaction that increases Sequence
-        by more than one). ``next_seq`` already added the +1 for the tx itself,
-        so callers pass ``by = TicketCount`` after submitting a TicketCreate to
-        keep a reused account's counter aligned with the ledger."""
+        """Bump tracked sequence by ``by`` (no-op if untracked). For TicketCreate:
+        it advances Sequence by TicketCount + 1 but next_seq only added the +1,
+        so callers pass ``by = TicketCount`` to keep a reused account aligned."""
         if address in self._seqs:
             self._seqs[address] += by
 

--- a/workload/src/workload/setup.py
+++ b/workload/src/workload/setup.py
@@ -1,20 +1,4 @@
-"""Deterministic setup for the Antithesis first_* phase.
-
-Creates the minimum ledger state needed for all transaction types to operate,
-including IOU gateways with token distribution, MPT authorization, and AMM pools.
-
-Account allocation:
-  [0..5]   — MPT issuers (one per flag cohort; [5] is the lockable cohort)
-  [10..16] — Vault creators (also get trust lines + IOU/MPT balances for non-XRP vaults)
-  [20..24] — NFT minters
-  [30..35] — Credential issuer + subjects
-  [40..42] — Ticket holders
-  [50..52] — Domain creators
-  [60..61] — IOU gateways (DefaultRipple + AllowTrustLineClawback set)
-  [62..71] — IOU/MPT holders (trust lines + balances for all currencies)
-  [62]     — also creates XRP/USD AMM
-  [63]     — also creates USD/EUR AMM
-"""
+"""Deterministic ledger-state setup for the Antithesis first_* phase."""
 
 from __future__ import annotations
 
@@ -104,7 +88,6 @@ def _accounts_list(workload: Workload) -> list[UserAccount]:
 async def _wait_for_state(
     items: list, expected: int, label: str, timeout: float = 15, poll: float = 1
 ) -> int:
-    """Wait for WS listener to populate a list. Returns actual count. Non-blocking."""
     elapsed = 0.0
     while len(items) < expected and elapsed < timeout:
         await asyncio.sleep(poll)
@@ -123,7 +106,6 @@ async def _submit_batch(
     client: AsyncJsonRpcClient,
     seq: SequenceTracker,
 ) -> int:
-    """Submit a batch with local sequence tracking."""
     if not txns:
         return 0
     created = 0
@@ -167,7 +149,6 @@ async def _submit_loan(
     interest_rate: int = _LOAN_INTEREST,
     payment_total: int = _LOAN_TOTAL,
 ) -> bool:
-    """Create a co-signed LoanSet. Returns True on success."""
     txn = LoanSet(
         account=borrower.address,
         loan_broker_id=broker_id,
@@ -201,12 +182,8 @@ async def _submit_loan(
 
 
 async def _probe_node(workload: Workload) -> None:
-    """Submit a no-op AccountSet to confirm the node accepts transactions.
-
-    Retries with backoff until accepted. The sync checks in wait_for_network
-    verify the node reports 'full', but that doesn't guarantee it will accept
-    transaction submissions — autofill and submit have stricter sync requirements.
-    """
+    # A 'full' sync report doesn't guarantee submit acceptance; retry until a
+    # no-op AccountSet is accepted (autofill/submit have stricter sync needs).
     max_wait = 300
     start = asyncio.get_event_loop().time()
     attempt = 0
@@ -256,7 +233,6 @@ async def _probe_node(workload: Workload) -> None:
 
 
 async def run_setup(workload: Workload) -> dict[str, int]:
-    """Submit deterministic setup transactions. State tracking via WS listener."""
     await _probe_node(workload)
     accs = _accounts_list(workload)
     client = workload.client
@@ -265,10 +241,7 @@ async def run_setup(workload: Workload) -> dict[str, int]:
 
     holder_indices = list(_HOLDER_RANGE) + list(_VAULT_RANGE)
 
-    # Record addresses used by setup so AccountDelete won't target them.
-    # Indices: gateways (60-61), MPT issuers (0-5), vault creators (10-16),
-    # NFT minters (20-24), credential issuer + subjects (30-35), ticket
-    # holders (40-42), domain creators (50-52), IOU/MPT holders (62-71).
+    # Record setup-owned addresses so AccountDelete won't target them.
     _setup_indices: set[int] = (
         set(range(6))
         | set(range(10, 17))
@@ -358,14 +331,9 @@ async def run_setup(workload: Workload) -> dict[str, int]:
     summary["iou_distribution"] = await _submit_batch("iou_distribution", iou_txns, client, seq)
 
     # ── 4. MPT issuances: 6 flag-distinct cohorts, one issuer each ───
-    # Flag-distinct cohorts so both valid DEX/AMM paths and the XLS-82 fault
-    # gates (tecNO_PERMISSION/tecNO_AUTH/tecLOCKED) become reachable:
-    #   [0] tradeable    CAN_LOCK | CAN_CLAWBACK | CAN_TRADE | CAN_TRANSFER
-    #   [1] tradeable    CAN_LOCK | CAN_CLAWBACK | CAN_TRADE | CAN_TRANSFER
-    #   [2] no-trade     CAN_LOCK
-    #   [3] no-transfer  CAN_LOCK | CAN_TRADE
-    #   [4] require-auth CAN_LOCK | CAN_TRADE | CAN_TRANSFER | REQUIRE_AUTH
-    #   [5] lockable     CAN_LOCK | CAN_CLAWBACK | CAN_TRADE | CAN_TRANSFER (locked in 6b)
+    # Flag-distinct cohorts so valid DEX/AMM paths AND XLS-82 fault gates
+    # (tecNO_PERMISSION/tecNO_AUTH/tecLOCKED) are all reachable; [5] is the
+    # lockable cohort locked in step 6b.
     _LOCK = MPTokenIssuanceCreateFlag.TF_MPT_CAN_LOCK
     _CLAW = MPTokenIssuanceCreateFlag.TF_MPT_CAN_CLAWBACK
     _TRADE = MPTokenIssuanceCreateFlag.TF_MPT_CAN_TRADE
@@ -445,10 +413,9 @@ async def run_setup(workload: Workload) -> dict[str, int]:
     )
 
     # ── 6b. MPT lock: lock the lockable issuance ─────────────────────
-    # The cohort minted from accs[5] is reserved for the locked state so the
-    # locked-MPT gates are reachable (tecLOCKED on offers/AMM, tecPATH_DRY on
-    # MPTokensV2 payments). Lock it after distribution so
-    # holders are funded before the freeze takes effect.
+    # Lock accs[5]'s cohort to make locked-MPT gates reachable (tecLOCKED on
+    # offers/AMM, tecPATH_DRY on MPTokensV2 payments). After distribution so
+    # holders are funded before the freeze.
     lock_count = 0
     if len(accs) > 5:
         lockable = next((m for m in workload.mpt_issuances if m.issuer == accs[5].address), None)
@@ -624,7 +591,6 @@ async def run_setup(workload: Workload) -> dict[str, int]:
         gw0_addr = accs[gw0_idx].address if gw0_idx < len(accs) else None
         gw1_addr = accs[gw1_idx].address if gw1_idx < len(accs) else None
 
-        # AMM 1: XRP / USD — created by holder account[62]
         if gw0_addr:
             amm_txns.append(
                 (
@@ -643,7 +609,6 @@ async def run_setup(workload: Workload) -> dict[str, int]:
                 )
             )
 
-        # AMM 2: USD / EUR — created by holder account[63]
         if gw0_addr and gw1_addr:
             amm_txns.append(
                 (
@@ -687,9 +652,8 @@ async def run_setup(workload: Workload) -> dict[str, int]:
             client,
             seq,
         )
-        # Subjects accept their credentials so they become permissioned-domain
-        # members (the step-11 domains accept {accs[30], _SETUP_CREDENTIAL_TYPE}).
-        # Setup credentials have no expiration, so membership stays stable.
+        # Subjects accept so they become members of the step-11 domains; setup
+        # credentials never expire, so membership stays stable.
         summary["credential_accepts"] = await _submit_batch(
             "credential_accepts",
             [
@@ -712,9 +676,8 @@ async def run_setup(workload: Workload) -> dict[str, int]:
         summary["credential_accepts"] = 0
 
     # ── 10. Tickets ──────────────────────────────────────────────────
-    # 40-42: generic ticket holders. 50-52: domain owners (always domain
-    # members) — giving them tickets makes the ticket x permissioned-DEX valid
-    # path reachable from setup (a ticket holder that is also a domain member).
+    # 50-52 (domain owners) also get tickets so the ticket x permissioned-DEX
+    # valid path (ticket holder that is also a domain member) is reachable.
     ticket_indices = [i for i in (40, 41, 42, 50, 51, 52) if i < len(accs)]
     summary["tickets"] = await _submit_batch(
         "tickets",
@@ -730,9 +693,8 @@ async def run_setup(workload: Workload) -> dict[str, int]:
         seq,
     )
     summary["tickets"] *= _TICKET_COUNT
-    # TicketCreate advances the account Sequence by TicketCount + 1; next_seq
-    # only counted the +1, so align the tracker for accounts reused later
-    # (e.g. domain owners 50-52 create their domains in step 11).
+    # TicketCreate advances Sequence by TicketCount + 1 but next_seq counted
+    # only +1; realign the tracker for accounts reused later (domains in step 11).
     for i in ticket_indices:
         seq.advance(accs[i].address, _TICKET_COUNT)
 

--- a/workload/src/workload/submit.py
+++ b/workload/src/workload/submit.py
@@ -1,9 +1,4 @@
-"""Fire-and-forget transaction submission.
-
-Autofills, signs, and submits a transaction via RPC without waiting for
-validation. The WebSocket listener (ws_listener.py) observes validated
-results and fires assertions / updates state.
-"""
+"""Fire-and-forget transaction submission; ws_listener.py handles validated results."""
 
 from collections.abc import Callable
 
@@ -26,11 +21,7 @@ _accounts: dict = {}
 
 
 def configure(delegates: list, accounts: dict) -> None:
-    """Store references to workload delegation state.
-
-    Called once during ``Workload.__init__`` so that ``submit_tx`` can
-    transparently apply delegation without any handler changes.
-    """
+    """Store delegation state once at init so submit_tx can apply it transparently."""
     global _delegates, _accounts
     _delegates = delegates
     _accounts = accounts
@@ -43,26 +34,16 @@ async def submit_tx(
     wallet: Wallet,
     seq: int | None = None,
 ) -> dict:
-    """Sign and submit a transaction. Returns the submit response result.
+    """Sign and submit; returns the tentative engine_result (final via WS listener).
 
-    The returned dict contains the preliminary (tentative) engine_result
-    and the transaction hash. Final results arrive via the WS listener.
-
-    If ``seq`` is provided, it is stamped onto the transaction before
-    autofill so that xrpl-py skips the RPC sequence fetch.
-
-    When delegation state is configured (via ``configure``), there is a
-    10% chance that a matching delegate will sign on behalf of the
-    source account for delegable transaction types.
-
-    Raises XRPLRequestFailureException on RPC-level failures (connection
-    refused, malformed request, etc.) — let it propagate to the endpoint
-    handler's XRPLException catch.
+    ``seq`` (if given) is stamped pre-autofill so xrpl-py skips the RPC seq fetch.
+    With delegation configured, a matching delegate co-signs ~10% of the time.
+    Lets XRPLRequestFailureException propagate to the handler's XRPLException catch.
     """
     if seq is not None:
         txn = txn.__replace__(sequence=seq)
 
-    # Possibly delegate: lazy import to avoid circular dependency
+    # Lazy import: avoids circular dependency.
     if _delegates:
         from workload.transactions.delegation import maybe_delegate
 
@@ -90,30 +71,13 @@ async def submit_raw(
     wallet: Wallet,
     mutate: Callable[[dict], None] | None = None,
 ) -> dict:
-    """Submit path for ``_faulty`` handlers — bypasses xrpl-py model validation.
+    """Raw ``_faulty`` submit path: autofill a valid ``base``, ``mutate(dict)`` it
+    into a malformation xrpl-py rejects at construction, then sign+submit raw so
+    rippled's preflight/preclaim does the rejecting.
 
-    Autofill a VALID ``base`` model (to obtain Sequence/Fee/LastLedgerSequence),
-    serialize it to an XRPL JSON dict, optionally apply ``mutate(dict)`` to
-    introduce a malformation xrpl-py would reject at construction (tfHybrid
-    without DomainID, empty/oversized/duplicate arrays, …), then sign and submit
-    the raw blob so rippled's own preflight/preclaim is what rejects it.
-
-    ``mutate`` is omitted when the faulty intent is already a valid model (e.g.
-    a non-member submitting a well-formed domain offer) — the raw path is still
-    used so every ``_faulty`` case shares one submission discipline.
-
-    Contract: ``mutate`` MUST keep ``tx_dict`` encodable. ``submit_raw`` has no
-    encode guard — only ``submit_fuzzed`` catches ``XRPLBinaryCodecException`` /
-    ``ValueError`` from a shape that won't serialize. Curated ``mutate`` fns are
-    therefore a caller obligation: produce a malformation rippled rejects in
-    preflight/preclaim, not one the binary codec rejects before submission.
-
-    Delegation is intentionally NOT applied here (unlike ``submit_tx``): faulty
-    intent stays attributable to a single signer, so a flagged result maps back
-    to exactly one account.
-
-    Wires ``tx_submitted`` exactly like ``submit_tx`` (seen + submit-time
-    internal-error assertion). Use ONLY in ``_faulty`` paths.
+    Contract: ``mutate`` MUST keep the dict encodable — submit_raw has no encode
+    guard (only submit_fuzzed catches XRPLBinaryCodecException / ValueError).
+    Delegation is intentionally NOT applied here so a flagged result maps to one account.
     """
     autofilled = await autofill(base, client)
     tx_dict = autofilled.to_xrpl()

--- a/workload/src/workload/transactions/__init__.py
+++ b/workload/src/workload/transactions/__init__.py
@@ -1,15 +1,4 @@
-"""Transaction registry — single source of truth for all transaction types.
-
-Every transaction type is defined here with its:
-- name: assertion name (used in TX_TYPES, workload::seen, etc.)
-- path: HTTP endpoint path
-- handler: async function to call
-- args: lambda taking Workload, returning args tuple for handler
-- state_updater: optional (workload, tx_json, meta) callback for WS listener
-
-To add a new transaction type: add one entry to REGISTRY below.
-app.py, assertions.py, and ws_listener.py all read from this.
-"""
+"""Transaction registry — single source of truth for all transaction types."""
 
 from __future__ import annotations
 
@@ -19,7 +8,6 @@ if TYPE_CHECKING:
     from workload.app import Workload
 
 # ── State updater helpers ────────────────────────────────────────────
-# Each handles a validated tesSUCCESS by updating workload tracking lists.
 import xrpl.models
 from xrpl.models import IssuedCurrency
 from xrpl.models.currencies import MPTCurrency
@@ -142,10 +130,7 @@ def _on_trust_set(w: Workload, tx: dict, meta: dict) -> None:
 def _parse_asset(
     raw: dict | str,
 ) -> IssuedCurrency | MPTCurrency | xrpl.models.XRP:
-    """Parse an Asset field from a transaction JSON into an xrpl-py model.
-
-    A plain string (e.g. an XRP drops amount) maps to XRP.
-    """
+    """A plain string (e.g. an XRP drops amount) maps to XRP."""
     if not isinstance(raw, dict):
         return xrpl.models.XRP()
     if "mpt_issuance_id" in raw:
@@ -170,7 +155,6 @@ def _on_vault_delete(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _extract_amount(tx: dict) -> int:
-    """Extract integer amount from a transaction's Amount field (drops or IOU/MPT value)."""
     amt = tx.get("Amount", "0")
     if isinstance(amt, str):
         return int(amt)
@@ -237,7 +221,7 @@ def _on_nftoken_cancel_offer(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_mpt_create(w: Workload, tx: dict, meta: dict) -> None:
-    # mpt_issuance_id is at the top level of meta (like nftoken_id for NFTs)
+    # mpt_issuance_id is at meta top level, like nftoken_id for NFTs
     mpt_id = meta.get("mpt_issuance_id")
     if mpt_id:
         flags = tx.get("Flags", 0)
@@ -247,7 +231,7 @@ def _on_mpt_create(w: Workload, tx: dict, meta: dict) -> None:
             can_trade=bool(flags & int(MPTokenIssuanceCreateFlag.TF_MPT_CAN_TRADE)),
             can_transfer=bool(flags & int(MPTokenIssuanceCreateFlag.TF_MPT_CAN_TRANSFER)),
             require_auth=bool(flags & int(MPTokenIssuanceCreateFlag.TF_MPT_REQUIRE_AUTH)),
-            # lock state is set later by setup, not at create
+            # lock state set later by setup, not at create
             locked=False,
         )
         w.mpt_issuances.append(issuance)
@@ -257,8 +241,8 @@ def _on_mpt_authorize(w: Workload, tx: dict, meta: dict) -> None:
     mpt_id = tx.get("MPTokenIssuanceID")
     if not mpt_id:
         return
-    # Holder self-opt-in: the submitter holds. Issuer-authorizes-holder mode:
-    # the Holder field names the account that now holds an MPToken.
+    # Holder self-opt-in: submitter holds. Issuer-authorizes mode: Holder field
+    # names the account that now holds.
     held = tx.get("Holder") or tx.get("Account", "")
     if not held:
         return
@@ -296,8 +280,7 @@ def _on_credential_delete(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_credential_accept(w: Workload, tx: dict, meta: dict) -> None:
-    # CredentialAccept sets lsfAccepted on the credential (a ModifiedNode, no
-    # created/deleted id). The subject is the submitting account.
+    # ModifiedNode only (no created/deleted id); subject is the submitter.
     issuer = tx.get("Issuer", "")
     subject = tx.get("Account", "")
     cred_type = tx.get("CredentialType", "")
@@ -316,8 +299,6 @@ def _on_ticket_create(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _parse_accepted_credentials(tx: dict) -> list[tuple[str, str]]:
-    """Extract (issuer, credential_type) pairs from a PermissionedDomainSet's
-    AcceptedCredentials array."""
     pairs: list[tuple[str, str]] = []
     for entry in tx.get("AcceptedCredentials", []):
         cred = entry.get("Credential", entry)
@@ -338,7 +319,7 @@ def _on_domain_set(w: Workload, tx: dict, meta: dict) -> None:
             )
         )
         return
-    # Update to an existing domain (ModifiedNode): refresh accepted credentials.
+    # ModifiedNode: refresh accepted credentials on existing domain.
     existing_id = tx.get("DomainID")
     if existing_id:
         for d in w.domains:
@@ -416,7 +397,7 @@ def _on_loan_manage(w: Workload, tx: dict, meta: dict) -> None:
     if not loan:
         return
     flags = tx.get("Flags", 0)
-    # TF_LOAN_DEFAULT = 0x00010000, TF_LOAN_IMPAIR = 0x00020000, TF_LOAN_UNIMPAIR = 0x00040000
+    # TF_LOAN_DEFAULT=0x00010000, TF_LOAN_IMPAIR=0x00020000, TF_LOAN_UNIMPAIR=0x00040000
     if flags & 0x00010000:
         loan.is_defaulted = True
     if flags & 0x00020000:
@@ -442,7 +423,7 @@ def _on_channel_create(w: Workload, tx: dict, meta: dict) -> None:
     if not channel_id:
         return
     tx_hash = tx.get("hash", "")
-    # Update placeholder channel_id with real ledger ID
+    # Replace placeholder channel_id (tx hash) with real ledger ID
     for ch in w.payment_channels:
         if ch.channel_id == tx_hash:
             ch.channel_id = channel_id
@@ -459,12 +440,11 @@ def _on_channel_create(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_channel_fund(w: Workload, tx: dict, meta: dict) -> None:
-    # Fund doesn't create/delete — just adds XRP to existing channel
+    # Fund neither creates nor deletes a channel — nothing to track.
     pass
 
 
 def _on_channel_claim(w: Workload, tx: dict, meta: dict) -> None:
-    # If the channel was closed by this claim, remove it
     deleted_id = _extract_deleted_id(meta, "PayChannel")
     if deleted_id:
         w.payment_channels[:] = [ch for ch in w.payment_channels if ch.channel_id != deleted_id]
@@ -475,12 +455,11 @@ def _on_check_create(w: Workload, tx: dict, meta: dict) -> None:
     if not check_id:
         return
     tx_hash = tx.get("hash", "")
-    # Update the placeholder check_id (tx hash) with real ledger check_id
+    # Replace placeholder check_id (tx hash) with real ledger check_id
     for c in w.checks:
         if c.check_id == tx_hash:
             c.check_id = check_id
             return
-    # If not found optimistically, add it
     w.checks.append(
         Check(
             check_id=check_id,
@@ -504,18 +483,16 @@ def _on_check_cancel(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_escrow_create(w: Workload, tx: dict, meta: dict) -> None:
-    """Confirm escrow creation — match by owner+sequence and keep fulfillment."""
+    # Escrow already appended optimistically by handler (keeps fulfillment);
+    # confirm by owner+sequence, only re-add as fallback.
     escrow_id = _extract_created_id(meta, "Escrow")
     if not escrow_id:
         return
     owner = tx.get("Account", "")
     seq = tx.get("Sequence", 0)
-    # The Escrow was already appended optimistically by escrow_create handler
-    # with sequence = tx sequence. Just confirm it exists.
     for e in w.escrows:
         if e.owner == owner and e.sequence == seq:
             return
-    # If not found (edge case), add without fulfillment
     w.escrows.append(
         Escrow(
             owner=owner,
@@ -546,7 +523,6 @@ def _on_escrow_cancel(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_did_set(w: Workload, tx: dict, meta: dict) -> None:
-    """Track DID in w.dids (idempotent)."""
     account = tx.get("Account", "")
     if not account:
         return
@@ -555,7 +531,6 @@ def _on_did_set(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_did_delete(w: Workload, tx: dict, meta: dict) -> None:
-    """Remove DID from w.dids."""
     account = tx.get("Account", "")
     w.dids[:] = [d for d in w.dids if d.account != account]
 
@@ -564,9 +539,8 @@ def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
     source = tx.get("Account", "")
     delegate_addr = tx.get("Authorize", "")
     perms_raw = tx.get("Permissions", [])
-    # Only keep permission values that are transaction type names;
-    # GranularPermission values (e.g. "TrustlineAuthorize") will never
-    # match a tx_type in maybe_delegate, so filter them out.
+    # GranularPermission values (e.g. "TrustlineAuthorize") never match a
+    # tx_type in maybe_delegate, so keep only tx-type-name permissions.
     tx_type_names = set(TX_TYPES)
     permissions = []
     for p in perms_raw:
@@ -575,7 +549,6 @@ def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
             permissions.append(pv)
     if not permissions:
         return
-    # Replace existing delegation from same source to same delegate
     w.delegates[:] = [
         d for d in w.delegates if not (d.source == source and d.delegate_address == delegate_addr)
     ]
@@ -591,14 +564,12 @@ def _on_delegate_set(w: Workload, tx: dict, meta: dict) -> None:
 def _on_amm_create(w: Workload, tx: dict, meta: dict) -> None:
     amm_id = _extract_created_id(meta, "AMM")
     if amm_id:
-        # Parse both assets from the AMMCreate transaction. Use _parse_asset so
-        # MPT amounts (dict with mpt_issuance_id, no currency) are tracked too.
+        # _parse_asset so MPT amounts (dict, no currency) are tracked too.
         asset1_raw = tx.get("Amount", {})
         asset2_raw = tx.get("Amount2", {})
         assets = [
             _parse_asset(raw) for raw in (asset1_raw, asset2_raw) if isinstance(raw, (dict, str))
         ]
-        # Extract LP token from created AMM node
         lp_token = []
         for node in meta.get("AffectedNodes", []):
             created = node.get("CreatedNode", {})
@@ -614,7 +585,7 @@ def _on_amm_create(w: Workload, tx: dict, meta: dict) -> None:
 def _on_amm_delete(w: Workload, tx: dict, meta: dict) -> None:
     amm_id = _extract_deleted_id(meta, "AMM")
     if amm_id:
-        # Match by asset pair — the deleter can be anyone, not just the creator.
+        # Match by asset pair — deleter can be anyone, not just the creator.
         tx_assets = {_parse_asset(tx.get("Asset", {})), _parse_asset(tx.get("Asset2", {}))}
         w.amms[:] = [a for a in w.amms if set(a.assets) != tx_assets]
 
@@ -632,20 +603,16 @@ def _on_offer_create(w: Workload, tx: dict, meta: dict) -> None:
 
 
 def _on_offer_cancel(w: Workload, tx: dict, meta: dict) -> None:
-    """Remove an explicitly cancelled offer from state.
-
-    NOTE: offers also disappear via fill and expiry, which don't trigger
-    this handler. Stale entries will accumulate in w.offers — the cancel-valid
-    path may pick already-gone offers and get tecNO_OFFER. This is acceptable
-    for fuzzing purposes (exercises error paths).
-    """
+    # Offers also vanish via fill/expiry (no handler), so stale entries
+    # accumulate; cancel-valid may then pick a gone offer (tecNO_OFFER), which
+    # is acceptable — it exercises error paths.
     deleted_id = _extract_deleted_id(meta, "Offer")
     if deleted_id:
         w.offers[:] = [o for o in w.offers if o.get("offer_id") != deleted_id]
 
 
 # ── Registry ─────────────────────────────────────────────────────────
-# (name, path, handler, args_fn, state_updater_or_None)
+# (name, path, handler, args_fn, state_updater | None)
 
 REGISTRY = [
     (
@@ -901,9 +868,8 @@ REGISTRY = [
         _on_offer_cancel,
     ),
     # ── Permissioned DEX (featurePermissionedDEX) ────────────────────
-    # Synthetic assertion names; on-ledger TransactionType stays OfferCreate /
-    # Payment. State is tracked by the real-type updaters (_on_offer_create),
-    # and ws_listener fires the matching tx_result for the buckets below.
+    # Synthetic names; on-ledger type stays OfferCreate/Payment. Real-type
+    # updaters track state; ws_listener fires tx_result for these buckets.
     (
         "OfferCreateDomain",
         "/offer/create/domain/random",
@@ -933,9 +899,8 @@ REGISTRY = [
         None,
     ),
     # ── MPT-on-DEX (XLS-82) ──────────────────────────────────────────
-    # Synthetic assertion name; on-ledger TransactionType stays OfferCreate.
-    # State is tracked by the real-type updater (_on_offer_create), and
-    # ws_listener fires the matching tx_result for the buckets below.
+    # Synthetic name; on-ledger type stays OfferCreate. Real-type updater
+    # tracks state; ws_listener fires tx_result for these buckets.
     (
         "OfferCreateMPT",
         "/offer/create/mpt/random",
@@ -943,9 +908,8 @@ REGISTRY = [
         lambda w: (w.accounts, w.mpt_issuances, w.client),
         None,
     ),
-    # PaymentMPT: a Payment carrying an MPT. Synthetic name; on-ledger type is
-    # Payment (no state updater — Payment has none). ws_listener fires the
-    # matching tx_result when a validated Payment carries an MPT leg.
+    # PaymentMPT: synthetic name; on-ledger type is Payment (no updater).
+    # ws_listener fires tx_result when a validated Payment carries an MPT leg.
     (
         "PaymentMPT",
         "/payment/mpt/random",
@@ -1116,6 +1080,5 @@ REGISTRY = [
     ),
 ]
 
-# Derived views for consumers
 TX_TYPES = [name for name, *_ in REGISTRY]
 STATE_UPDATERS = {name: updater for name, _, _, _, updater in REGISTRY if updater}

--- a/workload/src/workload/transactions/account_delete.py
+++ b/workload/src/workload/transactions/account_delete.py
@@ -1,21 +1,4 @@
-"""AccountDelete workload handler.
-
-AccountDelete removes an account from the ledger, sending remaining XRP
-to a destination.  Constraints enforced by rippled:
-  - Account's sequence must be ≥ current ledger seq - 256
-  - Account must own ZERO directory objects (trust lines, offers, escrows,
-    checks, channels, NFTs, vaults, etc.)
-  - Costs the owner reserve (typically 5 XRP) as fee
-
-This is a NON_DELEGABLE transaction — blocked by XRPL protocol.
-
-SAFETY: The valid path skips accounts in ``workload.protected_accounts``
-(addresses captured by setup: gateways, MPT issuers, vault creators,
-holders, NFT minters, credential subjects, ticket holders, domain
-creators).  Most submissions still get rejected because even "unused"
-accounts may have acquired objects from driver calls; the fuzzing value
-is exercising the transaction path itself.
-"""
+"""AccountDelete (NON_DELEGABLE); valid path skips protected_accounts to not break setup."""
 
 from __future__ import annotations
 
@@ -48,13 +31,11 @@ async def _account_delete_valid(
 
     acct_list = list(accounts.values())
 
-    # Skip setup-critical addresses
     expendable = [a for a in acct_list if a.address not in protected_accounts]
     if not expendable:
         return
 
     src = choice(expendable)
-    # Destination must differ from source — pick any other account
     dst = choice([a for a in acct_list if a.address != src.address])
 
     txn = AccountDelete(
@@ -81,13 +62,11 @@ async def _account_delete_faulty(
     )
 
     if mutation == "self_destination":
-        # Can't delete to self
         txn = AccountDelete(
             account=src.address,
             destination=src.address,
         )
     elif mutation == "fake_destination":
-        # Destination doesn't exist
         txn = AccountDelete(
             account=src.address,
             destination=params.fake_account(),

--- a/workload/src/workload/transactions/account_set.py
+++ b/workload/src/workload/transactions/account_set.py
@@ -1,8 +1,4 @@
-"""AccountSet transaction generators for the antithesis workload.
-
-Randomly sets/clears account flags that affect trust lines, payments,
-and other operations.
-"""
+"""AccountSet transaction generators: set/clear account flags."""
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import AccountSet, AccountSetAsfFlag
@@ -14,7 +10,7 @@ from workload.submit import submit_tx
 
 log = logging.getLogger(__name__)
 
-# Flags that are interesting for fuzzing trust lines and payments
+# Flags that affect trust lines and payments.
 INTERESTING_FLAGS: list[AccountSetAsfFlag] = [
     AccountSetAsfFlag.ASF_DEFAULT_RIPPLE,
     AccountSetAsfFlag.ASF_REQUIRE_AUTH,
@@ -39,7 +35,6 @@ async def _account_set_valid(accounts: dict[str, UserAccount], client: AsyncJson
     account_id = choice(list(accounts))
     account = accounts[account_id]
     flag = choice(INTERESTING_FLAGS)
-    # Randomly set or clear the flag
     if random() < 0.5:
         txn = AccountSet(account=account.address, set_flag=flag)
     else:

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -1,14 +1,4 @@
-"""AMM transaction generators for the antithesis workload.
-
-MPT-on-DEX (XLS-82, Phase 4): MPT assets are folded into the existing AMM
-handlers — no new synthetic names or REGISTRY entries. ``w.amms`` may now hold
-MPT-paired pools (``_on_amm_create`` tracks them via ``_parse_asset``), so every
-handler that does ``choice(amms)`` must build MPT amounts/assets correctly.
-xrpl-py accepts ``MPTCurrency`` in ``asset``/``asset2`` and ``MPTAmount`` in
-``amount``/``amount2``/``e_price`` for all six AMM models (verified at
-construction AND binary-codec encode), so the policy is HANDLE everywhere — no
-handler skips MPT pools.
-"""
+"""AMM transaction generators; MPT pools (XLS-82) are handled everywhere, not skipped."""
 
 import xrpl.models
 from xrpl.asyncio.clients import AsyncJsonRpcClient
@@ -49,12 +39,7 @@ def _find_account_with_trust_lines(
     trust_lines: list[TrustLine],
     needed_ious: list[IssuedCurrency],
 ) -> UserAccount | None:
-    """Find an account that has trust lines for all needed IOUs.
-
-    Accounts with trust lines received IOU distributions during setup,
-    so having the trust line implies having balance.
-    Returns None if no eligible account exists.
-    """
+    """Trust line implies balance: accounts got IOU distributions at setup."""
     if not needed_ious:
         return choice(list(accounts.values()))
 
@@ -76,18 +61,13 @@ def _find_account_with_trust_lines(
 def _pick_asset_pair(
     trust_lines: list[TrustLine],
 ) -> tuple[IssuedCurrency | xrpl.models.XRP, IssuedCurrency] | None:
-    """Pick a random asset pair for AMM creation.
-
-    Returns (asset1, asset2) where asset1 may be XRP and asset2 is always IOU.
-    Returns None if no trust lines exist.
-    """
+    """asset1 may be XRP, asset2 always IOU; None when no trust lines exist."""
     if not trust_lines:
         return None
     tl = choice(trust_lines)
     iou = IssuedCurrency(currency=tl.currency, issuer=tl.account_b)
     if random() < 0.3:
         return xrpl.models.XRP(), iou
-    # Pick a second different IOU
     other_tls = [t for t in trust_lines if t.currency != tl.currency or t.account_b != tl.account_b]
     if other_tls:
         tl2 = choice(other_tls)
@@ -97,20 +77,14 @@ def _pick_asset_pair(
 
 
 def _fake_iou() -> IssuedCurrency:
-    """Generate an IOU with a valid-format but non-existent issuer."""
+    """IOU with valid format but non-existent issuer."""
     return IssuedCurrency(currency=params.currency_code(), issuer=params.fake_account())
 
 
 def _amount_for(
     asset: IssuedCurrency | MPTCurrency | xrpl.models.XRP, value: str
 ) -> IOUAmount | MPTAmount | str:
-    """Build an amount for the given asset.
-
-    XRP -> drops string; IssuedCurrency -> IOUAmount; MPTCurrency -> MPTAmount.
-    ``value`` is an integer-or-decimal string; MPT amounts must be integers, and
-    all callers pass integer-valued ``params`` generators (amm_deposit_amount /
-    amm_withdraw_amount / mpt-safe values), so an MPTAmount is always well-formed.
-    """
+    """Callers pass integer ``value`` so MPTAmount (integers only) stays well-formed."""
     if isinstance(asset, xrpl.models.XRP):
         return value
     if isinstance(asset, MPTCurrency):
@@ -119,11 +93,7 @@ def _amount_for(
 
 
 def _iou_leg(amm: AMM) -> IssuedCurrency | None:
-    """Return an IOU leg of ``amm`` (skip XRP and MPT), or None if none exists.
-
-    Used by faulty vectors that build a signed-IOU amount (negative / overdraw)
-    which xrpl-py only models for IssuedCurrencyAmount — those vectors must skip
-    MPT-only pools rather than raise on ``MPTCurrency.currency``."""
+    """IOU leg (skip XRP/MPT), or None: signed-IOU faulty vectors must skip MPT-only pools."""
     for a in amm.assets:
         if isinstance(a, IssuedCurrency):
             return a
@@ -134,8 +104,7 @@ def _iou_leg(amm: AMM) -> IssuedCurrency | None:
 
 
 def _mpt_create_value() -> str:
-    """Integer MPT value for an AMM create leg, modest within the 10000 setup
-    distribution so a controlled holder can always fund it."""
+    """Modest within the 10000 setup distribution so a controlled holder can always fund it."""
     return params.amm_deposit_amount()
 
 
@@ -143,15 +112,7 @@ def _amm_create_mpt_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
 ) -> tuple[AMMCreate, UserAccount] | None:
-    """Build a valid MPT-paired AMMCreate + its creator. Shared by the valid path
-    and the fuzz faulty vector.
-
-    Primary shape: MPT+XRP (always fundable — XRP leg from amm_xrp_amount, MPT
-    leg from a tradeable issuance the creator is a controlled holder of). ~25%:
-    MPT+MPT from two distinct tradeable issuances whose controlled-holder sets
-    intersect (setup authorizes every holder for every issuance, so the holder
-    set is the intersection). Returns None when no tradeable MPT/holder exists.
-    """
+    """Valid MPT-paired AMMCreate + creator; None when no tradeable MPT/holder exists."""
     tr = _tradeable(mpt_issuances)
     if not tr or not accounts:
         return None
@@ -161,7 +122,7 @@ def _amm_create_mpt_base(
         return None
     mpt_amt1 = _amount_for(MPTCurrency(mpt_issuance_id=mpt1.mpt_issuance_id), _mpt_create_value())
 
-    # ~25%: try MPT+MPT with a second distinct tradeable issuance.
+    # ~25%: MPT+MPT needs a second issuance with an intersecting controlled-holder set.
     others = [m for m in tr if m.mpt_issuance_id != mpt1.mpt_issuance_id]
     if others and random() < 0.25:
         mpt2 = choice(others)
@@ -179,7 +140,6 @@ def _amm_create_mpt_base(
             )
             return base, src
 
-    # MPT+XRP.
     src = accounts[choice(holders1)]
     base = AMMCreate(
         account=src.address,
@@ -211,9 +171,7 @@ async def _amm_create_valid(
 ) -> None:
     if not accounts:
         return
-    # ~35%: build an MPT-paired pool when a tradeable MPT exists. Repeated
-    # same-pair creates hit tecDUPLICATE after the first — fine; the IOU/XRP
-    # majority keeps the success bucket green.
+    # ~35% MPT-paired; same-pair recreates hit tecDUPLICATE; IOU/XRP majority keeps success.
     if _tradeable(mpt_issuances) and random() < 0.35:
         built = _amm_create_mpt_base(accounts, mpt_issuances)
         if built is not None:
@@ -226,7 +184,6 @@ async def _amm_create_valid(
     if not pair:
         return
     asset1, asset2 = pair
-    # Find account that holds the needed IOUs
     needed = [a for a in [asset1, asset2] if not isinstance(a, xrpl.models.XRP)]
     src = _find_account_with_trust_lines(accounts, trust_lines, needed)
     if not src:
@@ -254,9 +211,7 @@ async def _amm_create_valid(
 
 
 def _mpt_xrp_create(account: str, mpt: MPTokenIssuance) -> AMMCreate:
-    """A well-formed MPT+XRP AMMCreate model (valid shape; the FAULT is which
-    issuance/creator is chosen, applied by rippled preclaim). Submitted via the
-    raw path so rippled's own preclaim is what rejects it."""
+    """Well-formed shape; the fault is the issuance/creator choice, left to rippled preclaim."""
     return AMMCreate(
         account=account,
         amount=_amount_for(MPTCurrency(mpt_issuance_id=mpt.mpt_issuance_id), _mpt_create_value()),
@@ -279,9 +234,7 @@ async def _amm_create_faulty(
     ra = _require_auth(mpt_issuances)
     lk = _locked(mpt_issuances)
 
-    # Existing IOU/XRP vectors stay on submit_tx. MPT vectors ride submit_raw /
-    # submit_fuzzed and are only offered when their cohort + a controlled holder
-    # exist.
+    # MPT vectors are only offered when their cohort + a controlled holder exist.
     mutations = [
         "non_existent_asset",
         "same_asset_both",
@@ -300,7 +253,6 @@ async def _amm_create_faulty(
     mutation = choice(mutations)
 
     if mutation == "fuzz":
-        # Generative: corrupt a valid MPT AMMCreate in open-ended ways.
         built = _amm_create_mpt_base(accounts, mpt_issuances)
         if built is None:
             return
@@ -309,11 +261,7 @@ async def _amm_create_faulty(
         return
 
     if mutation == "mpt_no_trade":
-        # CanTrade unset on the MPT leg -> tecNO_PERMISSION. Verified in
-        # AMMCreate.cpp:198-203 (canMPTTradeAndTransfer) -> MPTokenHelpers.cpp
-        # canTrade:590-591 returns tecNO_PERMISSION when lsfMPTCanTrade is unset.
-        # The creator is a controlled holder (funded), so the earlier
-        # tecUNFUNDED_AMM balance check (AMMCreate.cpp:171) is passed first.
+        # CanTrade unset -> tecNO_PERMISSION; creator is funded so the balance check passes first.
         usable = [m for m in nt if _controlled_holders(m, accounts)]
         mpt = choice(usable)
         creator = accounts[choice(_controlled_holders(mpt, accounts))]
@@ -322,11 +270,7 @@ async def _amm_create_faulty(
         return
 
     if mutation == "mpt_require_auth":
-        # require-auth MPT, creator a non-issuer holder never issuer-authorized
-        # -> tecNO_AUTH. Verified in AMMCreate.cpp:109-119 (requireAuth on the
-        # asset, AuthType::Legacy) -> MPTokenHelpers.cpp requireAuth:394-396
-        # (lsfMPTRequireAuth set AND MPToken lacks lsfMPTAuthorized). requireAuth
-        # runs before the canTrade/balance checks, so this is the dominant code.
+        # require-auth MPT, never-authorized holder -> tecNO_AUTH (runs before canTrade/balance).
         usable = [m for m in ra if any(a != m.issuer and a in m.holders for a in accounts)]
         mpt = choice(usable)
         holders = [a for a in _controlled_holders(mpt, accounts) if a != mpt.issuer]
@@ -338,11 +282,7 @@ async def _amm_create_faulty(
         return
 
     if mutation == "mpt_locked":
-        # Globally-locked MPT, creator a controlled holder (funded pre-lock)
-        # -> tecLOCKED (NOT tecFROZEN). Verified in AMMCreate.cpp:122-132
-        # (checkFrozen on the asset) -> TokenHelpers.cpp checkFrozen(MPTIssue):
-        # 96-99 returns tecLOCKED for a frozen/locked MPT. requireAuth passes
-        # first (locked cohort is not require-auth), then checkFrozen fires.
+        # Globally-locked MPT, funded holder -> tecLOCKED not tecFROZEN; checkFrozen after auth.
         usable = [m for m in lk if _controlled_holders(m, accounts)]
         mpt = choice(usable)
         creator = accounts[choice(_controlled_holders(mpt, accounts))]
@@ -393,8 +333,6 @@ async def _amm_create_faulty(
         )
 
     elif mutation == "duplicate_amm":
-        # Try to create an AMM for an asset pair that already exists (tecDUPLICATE).
-        # _amount_for handles XRP/IOU/MPT legs so MPT-paired pools are safe here.
         if not amms:
             return
         amm = choice(amms)
@@ -419,7 +357,6 @@ async def _amm_create_faulty(
         )
 
     else:  # unfunded_create
-        # Create with assets the account doesn't hold (tecUNFUNDED_AMM)
         fake = _fake_iou()
         amount2 = IOUAmount(
             currency=fake.currency,
@@ -628,7 +565,7 @@ async def _amm_deposit_faulty(
         )
 
     elif mutation == "mismatched_flag_fields":
-        # TF_TWO_ASSET but only provide one amount — flag/field mismatch
+        # TF_TWO_ASSET with only one amount
         if not amms:
             return
         amm = choice(amms)
@@ -649,8 +586,7 @@ async def _amm_deposit_faulty(
         amm = choice(amms)
         if len(amm.assets) < 2:
             return
-        # Signed-IOU amount: needs an IOU leg (XRP rejects negative drops at the
-        # codec; xrpl-py has no negative MPTAmount model) — skip MPT-only pools.
+        # Signed-IOU amount needs an IOU leg (no negative MPT/XRP model) — skip MPT-only pools.
         asset = _iou_leg(amm)
         if asset is None:
             return
@@ -853,15 +789,14 @@ async def _amm_withdraw_faulty(
         amm = choice(amms)
         if len(amm.assets) < 2:
             return
-        # Far-overshoot IOU value (within IOU precision, beyond any pool balance);
-        # needs an IOU leg — skip MPT-only pools (10**15 also overflows uint64).
+        # Needs an IOU leg — skip MPT-only pools (10**15 overflows uint64).
         asset = _iou_leg(amm)
         if asset is None:
             return
         amount = IOUAmount(
             currency=asset.currency,
             issuer=asset.issuer,
-            value=str(10**15),  # within IOU precision but far exceeds pool balance
+            value=str(10**15),
         )
         txn = AMMWithdraw(
             account=src.address,
@@ -872,7 +807,7 @@ async def _amm_withdraw_faulty(
         )
 
     elif mutation == "mismatched_flag_fields":
-        # TF_TWO_ASSET but only provide one amount — flag/field mismatch
+        # TF_TWO_ASSET with only one amount
         if not amms:
             return
         amm = choice(amms)
@@ -893,8 +828,7 @@ async def _amm_withdraw_faulty(
         amm = choice(amms)
         if len(amm.assets) < 2:
             return
-        # Signed-IOU amount: needs an IOU leg (XRP rejects negative drops at the
-        # codec; xrpl-py has no negative MPTAmount model) — skip MPT-only pools.
+        # Signed-IOU amount needs an IOU leg (no negative MPT/XRP model) — skip MPT-only pools.
         asset = _iou_leg(amm)
         if asset is None:
             return
@@ -933,9 +867,7 @@ async def _amm_vote_valid(
     if not accounts or not amms:
         return
     amm = choice(amms)
-    # Pick an account that holds the AMM's IOU assets (likely an LP token holder).
-    # Only IOU legs need a trust line; MPT/XRP legs are filtered out so an
-    # MPT-paired pool does not feed an MPTCurrency into the trust-line matcher.
+    # Filter to IOU legs: only those need a trust line, and MPTCurrency must not reach the matcher.
     needed = [a for a in amm.assets if isinstance(a, IssuedCurrency)]
     src = _find_account_with_trust_lines(accounts, trust_lines, needed)
     if not src:
@@ -969,7 +901,7 @@ async def _amm_vote_faulty(
         )
 
     elif mutation == "non_lp_holder_vote":
-        # Vote on a real AMM without holding LP tokens (tecAMM_FAILED)
+        # No LP tokens -> tecAMM_FAILED
         if not amms:
             return
         amm = choice(amms)
@@ -981,7 +913,7 @@ async def _amm_vote_faulty(
         )
 
     else:  # swapped_assets
-        # Vote with asset1/asset2 swapped (tecAMM_INVALID_TOKENS)
+        # asset1/asset2 swapped -> tecAMM_INVALID_TOKENS
         if not amms:
             return
         amm = choice(amms)
@@ -1129,7 +1061,7 @@ async def _amm_bid_faulty(
         )
 
     else:  # non_lp_holder_bid
-        # Bid on a real AMM without holding LP tokens (tecAMM_INVALID_TOKENS)
+        # No LP tokens -> tecAMM_INVALID_TOKENS
         if not amms:
             return
         amm = choice(amms)
@@ -1205,12 +1137,11 @@ async def _amm_delete_faulty(
             asset2=amm.assets[1] if len(amm.assets) > 1 else None,
         )
 
-    else:  # wrong_asset_pair — use real assets but wrong combination
+    else:  # wrong_asset_pair
         if not amms:
             return
         amm = choice(amms)
         fake = _fake_iou()
-        # Swap one real asset with a fake one
         txn = AMMDelete(
             account=src.address,
             asset=amm.assets[0],

--- a/workload/src/workload/transactions/batch.py
+++ b/workload/src/workload/transactions/batch.py
@@ -1,11 +1,4 @@
-"""Batch transaction generators for the antithesis workload.
-
-Inner transactions can be any type except Batch, Vault*, and Loan* operations
-(per Batch::disabledTxTypes in Batch.h).
-
-NOTE: When adding a new transaction type to the workload, consider adding it
-to _build_inner() as a batch inner type if it's not in the disabled list.
-"""
+"""Batch transaction generators for the antithesis workload."""
 
 import xrpl.models
 from xrpl.asyncio.account import get_next_valid_seq_number
@@ -42,8 +35,7 @@ _INNER_COMMON: dict[str, object] = {
     "signing_pub_key": "",
 }
 
-# All currently implemented types that are allowed in batch.
-# Excluded: Vault*, Loan* (in Batch::disabledTxTypes), Batch (cannot nest).
+# Excluded: Vault*, Loan* (Batch::disabledTxTypes), Batch (cannot nest).
 _INNER_TYPES: list[str] = [
     "Payment",
     "AccountSet",
@@ -58,7 +50,6 @@ _INNER_TYPES: list[str] = [
 
 
 def _build_inner(src: UserAccount, dst: str, sequence: int) -> Transaction:
-    """Build a random inner transaction for the batch."""
     tx_type = choice(_INNER_TYPES)
     common = {**_INNER_COMMON, "account": src.address, "sequence": sequence}
 

--- a/workload/src/workload/transactions/checks.py
+++ b/workload/src/workload/transactions/checks.py
@@ -1,12 +1,4 @@
-"""CheckCreate / CheckCash / CheckCancel workload handlers.
-
-A Check is a deferred payment: the creator authorises up to `send_max` to be
-pulled by the destination.  The destination cashes it for an exact `amount` or
-a flexible `deliver_min`.  Either party (or anyone after expiration) can cancel.
-
-State tracking keeps (check_id, creator, destination, send_max) so
-CheckCash and CheckCancel can reference live checks.
-"""
+"""CheckCreate / CheckCash / CheckCancel workload handlers."""
 
 from __future__ import annotations
 
@@ -52,13 +44,11 @@ async def _check_create_valid(
     )
     result = await submit_tx("CheckCreate", txn, client, src.wallet)
 
-    # Optimistically track — check_id comes from state updater,
-    # but we store a placeholder so CheckCash/Cancel have entries.
-    # Skip when the tx won't apply, so the placeholder doesn't leak.
+    # Track only when the submit will likely apply (state updater later swaps
+    # the hash placeholder for the real check_id), else the placeholder leaks.
     engine = result.get("engine_result", "") if result else ""
     if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ"):
         tx_json = result.get("tx_json", result)
-        # check_id = hash of the tx; the real one comes from meta
         check_id = tx_json.get("hash", "")
         if check_id:
             checks.append(
@@ -95,7 +85,6 @@ async def _check_create_faulty(
             send_max="0",
         )
     elif mutation == "self_destination":
-        # Create check to self (may or may not be valid depending on config)
         txn = CheckCreate(
             account=src.address,
             destination=src.address,
@@ -141,12 +130,11 @@ async def _check_cash_valid(
         return
 
     check = choice(checks)
-    # Only the destination can cash a check
+    # Only the destination can cash a check.
     dst = accounts.get(check.destination)
     if not dst:
         return
 
-    # Randomly use exact amount or deliver_min
     use_exact = choice([True, False])
     cash_amount = params.check_cash_amount(check.send_max)
 
@@ -194,7 +182,7 @@ async def _check_cash_faulty(
             check_id=params.fake_id(),
             amount="0",
         )
-    else:  # non_destination_cash — wrong account cashes
+    else:  # non_destination_cash
         txn = CheckCash(
             account=src.address,
             check_id=params.fake_id(),
@@ -226,7 +214,7 @@ async def _check_cancel_valid(
         return
 
     check = choice(checks)
-    # Creator or destination can cancel; pick one
+    # Creator or destination can cancel.
     canceller_addr = choice([check.creator, check.destination])
     canceller = accounts.get(canceller_addr)
     if not canceller:
@@ -259,7 +247,7 @@ async def _check_cancel_faulty(
             account=src.address,
             check_id=params.fake_id(),
         )
-    else:  # cancel_others_check — random account tries to cancel
+    else:  # cancel_others_check
         txn = CheckCancel(
             account=src.address,
             check_id=params.fake_id(),

--- a/workload/src/workload/transactions/clawback.py
+++ b/workload/src/workload/transactions/clawback.py
@@ -1,13 +1,4 @@
-"""Clawback workload handler — IOUs and MPTs.
-
-Clawback lets an issuer/gateway reclaim tokens from a holder.
-- IOU clawback: gateway is `account`, `amount.issuer` is the holder
-- MPT clawback: MPT issuer is `account`, `holder` field names the holder
-
-Only issuers with `lsfAllowTrustLineClawback` (gateways) or MPT issuers
-can clawback.  We use `w.trust_lines` and `w.mpt_issuances` to find
-valid (issuer, holder) pairs.
-"""
+"""Clawback workload handler — IOUs and MPTs."""
 
 from __future__ import annotations
 
@@ -41,7 +32,6 @@ async def _clawback_valid(
     if not accounts:
         return
 
-    # Pick IOU or MPT clawback based on available state
     can_iou = bool(trust_lines)
     can_mpt = bool(mpt_issuances)
     if not can_iou and not can_mpt:
@@ -92,7 +82,6 @@ async def _clawback_mpt_valid(
     if not issuer:
         return
 
-    # Find a holder — any account that isn't the issuer
     holders = [a for a in accounts.values() if a.address != mpt.issuer]
     if not holders:
         return
@@ -130,7 +119,6 @@ async def _clawback_faulty(
     )
 
     if mutation == "non_issuer_iou":
-        # Non-gateway tries to claw back IOU
         dst = choice(list(accounts.values()))
         txn = Clawback(
             account=src.address,
@@ -151,7 +139,6 @@ async def _clawback_faulty(
             ),
         )
     elif mutation == "fake_holder_mpt":
-        # Claw back from non-existent holder
         if mpt_issuances:
             mpt = choice(mpt_issuances)
             issuer = accounts.get(mpt.issuer) or src
@@ -166,7 +153,6 @@ async def _clawback_faulty(
             holder=params.fake_account(),
         )
     elif mutation == "non_issuer_mpt":
-        # Non-issuer tries to claw back MPT
         txn = Clawback(
             account=src.address,
             amount=MPTAmount(

--- a/workload/src/workload/transactions/credentials.py
+++ b/workload/src/workload/transactions/credentials.py
@@ -1,4 +1,4 @@
-"""Credential transaction generators for the antithesis workload."""
+"""Credential transaction generators."""
 
 import time
 

--- a/workload/src/workload/transactions/delegation.py
+++ b/workload/src/workload/transactions/delegation.py
@@ -1,4 +1,4 @@
-"""Delegation transaction generators for the antithesis workload."""
+"""Delegation transaction generators."""
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import DelegateSet
@@ -101,7 +101,6 @@ async def _delegate_set_faulty(
 
 # ── Delegation helper for submit_tx ──────────────────────────────────
 
-# Names of non-delegable transaction types for fast lookup.
 _NON_DELEGABLE_NAMES: set[str] = {t.value for t in NON_DELEGABLE_TRANSACTIONS}
 
 
@@ -111,13 +110,7 @@ def maybe_delegate(
     delegates: list,
     accounts: dict[str, UserAccount],
 ) -> tuple[str | None, object | None]:
-    """Possibly pick a delegate to submit *tx_type* on behalf of *src_address*.
-
-    Returns ``(delegate_address, delegate_wallet)`` when delegation should
-    happen, or ``(None, None)`` otherwise.
-
-    Called from ``submit_tx`` — no handler changes required.
-    """
+    """Pick a delegate for tx_type on behalf of src_address, or (None, None)."""
     from workload.randoms import random as _random
 
     if tx_type in _NON_DELEGABLE_NAMES:

--- a/workload/src/workload/transactions/did.py
+++ b/workload/src/workload/transactions/did.py
@@ -1,4 +1,4 @@
-"""DID transaction generators for the antithesis workload."""
+"""DID transaction generators."""
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import DIDDelete, DIDSet

--- a/workload/src/workload/transactions/domains.py
+++ b/workload/src/workload/transactions/domains.py
@@ -28,12 +28,8 @@ async def permissioned_domain_set(
 
 
 def _accepted_from_real_credentials(credentials: list[Credential]) -> list[XRPLCredential] | None:
-    """Build accepted_credentials from real (preferably accepted) credentials so
-    the domain gains actual members — their subjects — not just the owner.
-
-    Random issuer/type pairs (the fallback) match no real credential, leaving the
-    domain owner-only and starving the >=2-member paths (PaymentDomain, ticket
-    domain payments)."""
+    """Use real credentials so the domain gains members; random pairs leave it
+    owner-only and starve the >=2-member paths (PaymentDomain, ticket domain payments)."""
     pool = [c for c in credentials if c.accepted] or credentials
     if not pool:
         return None
@@ -54,12 +50,10 @@ def _domain_set_base(
     domains: list[PermissionedDomain],
     credentials: list[Credential],
 ) -> tuple[PermissionedDomainSet, object]:
-    """Build a valid PermissionedDomainSet (sometimes a create, sometimes an
-    update of an owned domain) + its wallet. Shared by the valid and fuzz paths."""
+    """Valid PermissionedDomainSet (create/update an owned domain) + wallet."""
     accepted = _accepted_from_real_credentials(credentials) or _accepted_random(accounts)
     own_domains = [d for d in domains if d.owner in accounts]
     if own_domains and params.should_update_domain():
-        # Update an existing domain's accepted credentials (the modify path).
         domain = choice(own_domains)
         src = accounts[domain.owner]
         base = PermissionedDomainSet(
@@ -106,7 +100,6 @@ async def _permissioned_domain_set_faulty(
     )
 
     if mutation == "fuzz":
-        # Generative: corrupt a valid PermissionedDomainSet in open-ended ways.
         base, wallet = _domain_set_base(accounts, domains, credentials)
         await submit_fuzzed("PermissionedDomainSet", base, client, wallet)
         return
@@ -144,8 +137,7 @@ async def _permissioned_domain_set_faulty(
                 ctype = params.credential_type()
                 d["AcceptedCredentials"] = [_cred(ctype), _cred(ctype)]
 
-    # Base is always a valid model (>=1 distinct credential); mutate (when set)
-    # introduces the malformed array shape after serialization.
+    # Base is a valid model; mutate (when set) injects the malformed array post-serialization.
     base = PermissionedDomainSet(
         account=src.address,
         domain_id=domain_id,
@@ -171,8 +163,7 @@ async def permissioned_domain_delete(
 def _domain_delete_base(
     accounts: dict[str, UserAccount], domains: list[PermissionedDomain]
 ) -> tuple[PermissionedDomainDelete, object] | None:
-    """Build a valid PermissionedDomainDelete (owner deletes own domain) + its
-    wallet. Shared by the valid and fuzz paths."""
+    """Valid PermissionedDomainDelete (owner deletes own domain) + wallet."""
     if not domains:
         return None
     domain = choice(domains)
@@ -201,7 +192,6 @@ async def _permissioned_domain_delete_faulty(
     src = choice(list(accounts.values()))
     mutation = choice(["non_owner", "nonexistent", "zero_domain", "fuzz"])
     if mutation == "fuzz":
-        # Generative: corrupt a valid PermissionedDomainDelete in open-ended ways.
         built = _domain_delete_base(accounts, domains)
         if built is None:
             return

--- a/workload/src/workload/transactions/escrow.py
+++ b/workload/src/workload/transactions/escrow.py
@@ -1,14 +1,4 @@
-"""EscrowCreate / EscrowFinish / EscrowCancel workload handlers.
-
-Supports three escrow flavours:
-- Time-only: finish_after + cancel_after, no crypto-condition
-- Condition-only: crypto-condition, no time constraints
-- Time + condition: both time gates and crypto-condition
-
-State tracking keeps (owner, destination, sequence, condition, fulfillment,
-finish_after, cancel_after) so EscrowFinish and EscrowCancel can reference
-live escrows.
-"""
+"""EscrowCreate / EscrowFinish / EscrowCancel workload handlers."""
 
 from __future__ import annotations
 
@@ -47,7 +37,6 @@ async def _escrow_create_valid(
 
     amount = params.escrow_amount()
 
-    # Pick escrow flavour
     flavour = choice(["time_only", "condition_only", "time_and_condition"])
 
     condition = None
@@ -75,11 +64,8 @@ async def _escrow_create_valid(
     )
     result = await submit_tx("EscrowCreate", txn, client, src.wallet)
 
-    # Optimistically track the escrow with its fulfillment so
-    # EscrowFinish can use it later.  Sequence comes from autofill.
-    # Only track when the submit response indicates the tx will likely
-    # apply — otherwise the entry leaks forever and downstream Finish/Cancel
-    # picks dead escrows.
+    # Track only when the submit will likely apply, else the entry leaks and
+    # Finish/Cancel pick dead escrows.
     engine = result.get("engine_result", "") if result else ""
     if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ"):
         tx_json = result.get("tx_json", result)
@@ -115,7 +101,6 @@ async def _escrow_create_faulty(
         ]
     )
     if mutation == "past_cancel_after":
-        # cancel_after in the past
         past = params._ripple_now() - randint(100, 10_000)
         txn = EscrowCreate(
             account=src.address,
@@ -131,7 +116,7 @@ async def _escrow_create_faulty(
             cancel_after=params.escrow_finish_after() + 600,
         )
     elif mutation == "bad_condition_hex":
-        # Malformed condition — valid hex but not a valid crypto-condition
+        # Valid hex but not a valid crypto-condition.
         bad_cond = params.fake_id()
         txn = EscrowCreate(
             account=src.address,
@@ -140,7 +125,7 @@ async def _escrow_create_faulty(
             condition=bad_cond,
             cancel_after=params.escrow_finish_after() + 600,
         )
-    else:  # no_time_no_condition — escrow with no finish/cancel/condition
+    else:  # no_time_no_condition
         txn = EscrowCreate(
             account=src.address,
             amount=params.escrow_amount(),
@@ -172,7 +157,7 @@ async def _escrow_finish_valid(
         return
 
     escrow = choice(escrows)
-    # Anyone can finish an escrow (not just owner/destination)
+    # Anyone can finish an escrow.
     src = choice(list(accounts.values()))
 
     txn = EscrowFinish(
@@ -207,7 +192,7 @@ async def _escrow_finish_faulty(
             offer_sequence=randint(900_000, 999_999),
         )
     elif mutation == "wrong_fulfillment":
-        # Valid condition/fulfillment pair but mismatched
+        # Two valid pairs, deliberately mismatched.
         cond, _ = params.escrow_condition_pair()
         _, wrong_ful = params.escrow_condition_pair()
         txn = EscrowFinish(
@@ -218,7 +203,6 @@ async def _escrow_finish_faulty(
             fulfillment=wrong_ful,
         )
     else:  # wrong_owner
-        # Non-existent owner
         txn = EscrowFinish(
             account=src.address,
             owner=params.fake_account(),
@@ -249,13 +233,12 @@ async def _escrow_cancel_valid(
     if not escrows:
         return
 
-    # Prefer escrows with cancel_after set
     cancellable = [e for e in escrows if e.cancel_after is not None]
     if not cancellable:
         return
 
     escrow = choice(cancellable)
-    # Anyone can cancel an expired escrow
+    # Anyone can cancel an expired escrow.
     src = choice(list(accounts.values()))
 
     txn = EscrowCancel(
@@ -293,7 +276,7 @@ async def _escrow_cancel_faulty(
             owner=params.fake_account(),
             offer_sequence=randint(1, 100),
         )
-    else:  # cancel_non_cancellable — try to cancel with wrong sequence
+    else:  # cancel_non_cancellable
         txn = EscrowCancel(
             account=src.address,
             owner=src.address,

--- a/workload/src/workload/transactions/lending.py
+++ b/workload/src/workload/transactions/lending.py
@@ -1,8 +1,4 @@
-"""Lending Protocol transaction generators for the antithesis workload.
-
-Lending requires a vault to exist first, then a broker is created on that vault,
-then loans are taken against the broker.
-"""
+"""Lending Protocol transaction generators (vault → broker → loan chain)."""
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.asyncio.transaction import autofill_and_sign
@@ -254,7 +250,6 @@ async def loan_broker_cover_withdraw(
 
 
 def _state_aware_cover_withdraw_amount(broker: LoanBroker) -> str:
-    """Generate a cover withdraw amount informed by tracked cover balance."""
     if broker.cover_balance <= 0:
         return params.loan_cover_deposit_amount()
     strategy = choice(["exact", "half", "small"])
@@ -374,7 +369,7 @@ async def _loan_set_valid(
         payment_interval=pi,
         grace_period=params.loan_grace_period(pi),
     )
-    # LoanSet requires counterparty co-signing: borrower signs, then broker co-signs
+    # LoanSet requires co-signing: borrower signs, then broker co-signs.
     signed = await autofill_and_sign(txn, client, borrower.wallet)
     cosigned = sign_loan_set_by_counterparty(broker_wallet, signed)
     response = await xrpl_submit(cosigned.tx, client)
@@ -431,7 +426,7 @@ async def _loan_set_faulty(
             payment_interval=pi,
             grace_period=params.loan_grace_period(pi),
         )
-        # Deliberately skip co-signing — submit with only borrower's signature
+        # Fault: deliberately skip co-signing (borrower signature only).
         await submit_tx("LoanSet", txn, client, borrower.wallet)
 
 
@@ -451,7 +446,7 @@ async def _loan_delete_valid(
 ) -> None:
     if not loans:
         return
-    # Prefer loans with zero principal — loans with debt return tecHAS_OBLIGATIONS
+    # Prefer paid-off loans; loans with debt return tecHAS_OBLIGATIONS.
     paid_off = [ln for ln in loans if ln.principal <= 0 and ln.borrower in accounts]
     loan = choice(paid_off) if paid_off else choice(loans)
     if loan.borrower not in accounts:
@@ -509,14 +504,11 @@ async def loan_manage(
 
 
 def _state_aware_manage_flag(loan: Loan) -> LoanManageFlag:
-    """Pick a contextually appropriate manage flag based on loan state."""
     if loan.is_defaulted:
-        # Already defaulted — try impair/unimpair (likely errors, good for exploration)
+        # Already defaulted: impair/unimpair likely error — good for exploration.
         return choice([LoanManageFlag.TF_LOAN_IMPAIR, LoanManageFlag.TF_LOAN_UNIMPAIR])
     if loan.is_impaired:
-        # Impaired — can unimpair or escalate to default
         return choice([LoanManageFlag.TF_LOAN_UNIMPAIR, LoanManageFlag.TF_LOAN_DEFAULT])
-    # Normal — can impair or default
     return choice([LoanManageFlag.TF_LOAN_IMPAIR, LoanManageFlag.TF_LOAN_DEFAULT])
 
 
@@ -599,7 +591,6 @@ async def loan_pay(
 
 
 def _state_aware_pay_amount(loan: Loan) -> str:
-    """Generate a pay amount informed by tracked loan principal."""
     if loan.principal <= 0:
         return params.loan_pay_amount()
     strategy = choice(["full", "installment", "random"])

--- a/workload/src/workload/transactions/mpt.py
+++ b/workload/src/workload/transactions/mpt.py
@@ -78,7 +78,7 @@ async def _mpt_authorize_valid(
     mode = choice(["holder_optin", "issuer_auth"])
 
     if mode == "holder_optin":
-        # Holder self-authorization (opt-in) — works for any MPT
+        # opt-in works for any MPT; issuer_auth needs TF_MPT_REQUIRE_AUTH
         holder = accounts[choice(other_accounts)]
         txn = MPTokenAuthorize(
             account=holder.address,
@@ -86,7 +86,6 @@ async def _mpt_authorize_valid(
         )
         await submit_tx("MPTokenAuthorize", txn, client, holder.wallet)
     else:
-        # Issuer authorizes a holder — only works with TF_MPT_REQUIRE_AUTH
         issuer = accounts[mpt.issuer]
         holder_id = choice(other_accounts)
         txn = MPTokenAuthorize(

--- a/workload/src/workload/transactions/mpt_dex.py
+++ b/workload/src/workload/transactions/mpt_dex.py
@@ -1,54 +1,4 @@
-"""MPT-on-DEX workload handlers (XLS-82).
-
-Two synthetic assertion names share this module; the on-ledger TransactionType
-stays ``OfferCreate`` / ``Payment`` in each case. ws_listener fires the matching
-``tx_result(...)`` when a validated transaction carries an MPT leg, so the
-success/failure buckets for the synthetic name resolve (mirrors the
-permissioned-DEX precedent).
-
-OfferCreateMPT — an OfferCreate with an MPT leg.
-
-Direction semantics: ``TakerGets`` is what the offer owner SELLS; ``TakerPays``
-is what the owner BUYS. A buy-MPT-for-XRP offer (taker_gets=XRP, taker_pays=MPT)
-needs only XRP funding so any account can place it and it rests (the book for
-this MPT pair is typically empty), reliably tesSUCCESS. A sell-MPT-for-XRP offer
-by the issuer is also reliable (the issuer is funding-exempt on the TakerGets
-leg).
-
-XLS-82 gates exercised by the OfferCreate faulty path: both legs must carry
-lsfMPTCanTrade (else tecNO_PERMISSION); receiving a require-auth MPT the holder
-was never issuer-authorized for → tecNO_AUTH; a globally-locked MPT leg →
-tecLOCKED; a nonexistent issuance in TakerPays → tecNO_ISSUER (checkAcceptAsset
-reads the issuer embedded in the MPTokenIssuanceID); a non-holder selling MPT it
-does not hold → tecUNFUNDED_OFFER; same asset both legs → temREDUNDANT; zero MPT
-value → temBAD_OFFER (preflight saTakerPays <= kZero).
-
-PaymentMPT — a Payment carrying an MPT. The reliable valid surface is a direct
-holder→holder transfer of a tradeable MPT (CanTransfer set, both parties
-opted-in and funded by setup) → tesSUCCESS. With featureMPTokensV2 enabled a
-direct MPT payment routes through the payment engine (MPTEndpointPaymentStep),
-not the legacy V1 direct path, so its failure codes are the engine's:
-
-* dst with no MPToken (unauthorized receiver) → tecNO_AUTH
-  (MPTokenHelpers.cpp requireAuth, MPToken_test.cpp:1336-1342)
-* CanTransfer unset, holder→holder → tecNO_AUTH
-  (MPTokenHelpers.cpp canTransfer, MPToken_test.cpp:1321)
-* require-auth MPT to an unauthorized holder → tecNO_AUTH (requireAuth)
-* globally/individually locked, holder→holder → tecPATH_DRY under MPTokensV2
-  (terLOCKED from MPTEndpointStep::check is a retry code mapped to tecPATH_DRY
-  in Payment::doApply; MPToken_test.cpp:1379-1385 — NOT tecLOCKED)
-* deliver more than the source holds → tecPATH_PARTIAL
-  (Payment::doApply / MPToken_test.cpp:1359-1362)
-* nonexistent issuance → tecOBJECT_NOT_FOUND (requireAuth reads the issuance
-  keylet; MPToken_test.cpp:1656,1685)
-* zero/negative MPT Amount → temBAD_AMOUNT (preflight dstAmount <= kZero;
-  MPToken_test.cpp:1025-1029)
-
-A cross-token best-effort variant (SendMax in XRP, deliver MPT) routes through
-the order book and ends tecPATH_DRY with no resting liquidity
-(MPToken_test.cpp:4862 family); the direct path guarantees the success bucket,
-so PaymentMPT is NOT in assertions._NO_SUCCESS_TYPES.
-"""
+"""MPT-on-DEX (XLS-82): OfferCreateMPT, PaymentMPT submitted as OfferCreate/Payment."""
 
 from __future__ import annotations
 
@@ -64,12 +14,10 @@ from workload.randoms import choice, randint, random, sample
 from workload.submit import submit_raw, submit_tx
 
 # ── Cohort filter helpers ───────────────────────────────────────────
-# Defensively skip ``locked`` wherever a usable token is required.
 
 
 def _tradeable(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
-    """Issuances usable on both legs of a resting offer: CanTrade + CanTransfer,
-    not require-auth (our setup never issuer-authorizes), not locked."""
+    """Usable on both offer legs: CanTrade + CanTransfer, not require-auth, not locked."""
     return [
         m
         for m in mpts
@@ -78,26 +26,22 @@ def _tradeable(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
 
 
 def _no_trade(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
-    """Issuances missing lsfMPTCanTrade → an offer leg referencing them gets
-    tecNO_PERMISSION."""
+    """Missing CanTrade → offer leg gets tecNO_PERMISSION."""
     return [m for m in mpts if m.can_trade is False]
 
 
 def _require_auth(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
-    """Require-auth issuances (still CanTrade in our setup) whose holders were
-    never issuer-authorized → receiving them gets tecNO_AUTH."""
+    """Require-auth, holders never authorized → receiving gets tecNO_AUTH."""
     return [m for m in mpts if m.require_auth and not m.locked]
 
 
 def _locked(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
-    """Globally-locked issuances → an offer leg referencing them gets tecLOCKED."""
+    """Globally-locked → offer leg gets tecLOCKED."""
     return [m for m in mpts if m.locked]
 
 
 def _no_transfer(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
-    """Tradeable issuances missing lsfMPTCanTransfer (the idx3 setup cohort):
-    holders are opted-in and funded, but a holder→holder transfer fails
-    canTransfer → tecNO_AUTH. CanTrade is set so they are not in _no_trade."""
+    """CanTrade but not CanTransfer → holder→holder transfer fails canTransfer (tecNO_AUTH)."""
     return [
         m
         for m in mpts
@@ -106,7 +50,7 @@ def _no_transfer(mpts: list[MPTokenIssuance]) -> list[MPTokenIssuance]:
 
 
 def _controlled_holders(mpt: MPTokenIssuance, accounts: dict[str, UserAccount]) -> list[str]:
-    """Holders of ``mpt`` that we control (and so are funded by setup)."""
+    """Holders we control (hence funded by setup)."""
     return [h for h in mpt.holders if h in accounts]
 
 
@@ -127,11 +71,8 @@ def _offer_mpt_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
 ) -> tuple[OfferCreate, Wallet] | None:
-    """Build a valid MPT offer + its signing wallet. Shared by valid and fuzz.
-
-    ~40%: if we control the issuer, the issuer SELLS the MPT for XRP
-    (funding-exempt). Otherwise any account BUYS the MPT for XRP (needs only
-    XRP funding, rests in an empty book)."""
+    """Valid MPT offer + wallet; shared by valid and fuzz. ~40% issuer sells
+    (funding-exempt), else any account buys MPT for XRP (rests in empty book)."""
     tr = _tradeable(mpt_issuances)
     if not tr or not accounts:
         return None
@@ -172,13 +113,11 @@ async def _offer_create_mpt_faulty(
     lk = _locked(mpt_issuances)
     xrp = params.offer_xrp_drops()
 
-    # Build the conditional mutation list: only include a vector when its cohort
-    # (and the accounts it needs) exists. fake_mpt is always available.
+    # Include a vector only when its cohort + accounts exist; fake_mpt always available.
     mutations = ["fake_mpt"]
     if tr:
         mutations += ["fuzz", "redundant", "zero_amount"]
-        # unfunded_sell needs a tradeable MPT with at least one account that is
-        # neither the issuer nor a tracked holder (so its balance is provably 0).
+        # unfunded_sell needs a non-issuer non-holder (provably zero balance).
         if any(any(a != m.issuer and a not in m.holders for a in accounts) for m in tr):
             mutations.append("unfunded_sell")
     if nt:
@@ -190,7 +129,6 @@ async def _offer_create_mpt_faulty(
     mutation = choice(mutations)
 
     if mutation == "fuzz":
-        # Generative: corrupt a valid MPT offer in open-ended ways.
         built = _offer_mpt_base(accounts, mpt_issuances)
         if built is None:
             return
@@ -199,7 +137,7 @@ async def _offer_create_mpt_faulty(
         return
 
     if mutation == "not_tradeable":
-        # Any account BUYS a no-CanTrade MPT -> tecNO_PERMISSION.
+        # Buy a no-CanTrade MPT -> tecNO_PERMISSION.
         mpt = choice(nt)
         acct = accounts[choice(list(accounts))]
         base = OfferCreate(
@@ -213,9 +151,8 @@ async def _offer_create_mpt_faulty(
         return
 
     if mutation == "fake_mpt":
-        # Any account BUYS a nonexistent MPT issuance -> tecNO_ISSUER.
-        # checkAcceptAsset reads the issuer embedded in the fake MPTokenIssuanceID
-        # (its trailing 20 bytes) and rejects before canTrade is reached.
+        # Buy a nonexistent issuance -> tecNO_ISSUER (checkAcceptAsset reads the
+        # issuer embedded in the fake ID before canTrade).
         acct = accounts[choice(list(accounts))]
         base = OfferCreate(
             account=acct.address,
@@ -228,9 +165,7 @@ async def _offer_create_mpt_faulty(
         return
 
     if mutation == "unfunded_sell":
-        # A non-holder SELLS a tradeable MPT it does not hold -> tecUNFUNDED_OFFER.
-        # The seller is neither the issuer (funding-exempt) nor a tracked holder,
-        # so its balance is provably zero — any positive value suffices.
+        # Non-holder sells a tradeable MPT it does not hold -> tecUNFUNDED_OFFER.
         mpt = choice(tr)
         non_holders = [a for a in accounts if a != mpt.issuer and a not in mpt.holders]
         if not non_holders:
@@ -247,9 +182,8 @@ async def _offer_create_mpt_faulty(
         return
 
     if mutation == "require_auth":
-        # A non-issuer BUYS a require-auth MPT it was never authorized for
-        # -> tecNO_AUTH (receiving the MPT runs requireAuth). The issuer is
-        # exempt and would rest as tesSUCCESS, so exclude it.
+        # Non-issuer buys a require-auth MPT it was never authorized for ->
+        # tecNO_AUTH. Issuer is exempt (would rest tesSUCCESS), so exclude it.
         mpt = choice(ra)
         buyers = [a for a in accounts if a != mpt.issuer]
         if not buyers:
@@ -266,8 +200,7 @@ async def _offer_create_mpt_faulty(
         return
 
     if mutation == "locked":
-        # Any account BUYS a globally-locked MPT -> tecLOCKED
-        # (MPT path of checkGlobalFrozen).
+        # Buy a globally-locked MPT -> tecLOCKED.
         mpt = choice(lk)
         acct = accounts[choice(list(accounts))]
         base = OfferCreate(
@@ -281,8 +214,7 @@ async def _offer_create_mpt_faulty(
         return
 
     if mutation == "redundant":
-        # Same MPT on both legs -> temREDUNDANT. Build a valid BUY base, then
-        # copy the MPT TakerPays onto TakerGets.
+        # Same MPT on both legs -> temREDUNDANT.
         mpt = choice(tr)
         acct = accounts[choice(list(accounts))]
         base = OfferCreate(
@@ -299,9 +231,8 @@ async def _offer_create_mpt_faulty(
         await submit_raw("OfferCreateMPT", base, client, acct.wallet, mutate)
         return
 
-    # zero_amount — set the MPT leg's value to "0" -> temBAD_OFFER (preflight
-    # saTakerPays <= beast::kZero). xrpl-py accepts MPTAmount(value="0"), so the
-    # zero is injected via the raw path and rippled preflight is what rejects it.
+    # zero_amount — MPT leg value "0" -> temBAD_OFFER. xrpl-py accepts value="0",
+    # so the zero goes via the raw path for rippled preflight to reject.
     mpt = choice(tr)
     acct = accounts[choice(list(accounts))]
     base = OfferCreate(
@@ -336,12 +267,8 @@ def _payment_mpt_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
 ) -> tuple[Payment, Wallet] | None:
-    """Build a reliable direct holder→holder MPT transfer + its wallet. Shared
-    by the valid and fuzz paths.
-
-    Picks a tradeable issuance with at least two controlled (hence funded)
-    holders and moves a modest value (<=1000, well within the 10000 setup
-    distribution) between them → reliable tesSUCCESS. No SendMax, no Paths."""
+    """Reliable direct holder→holder MPT transfer + wallet; shared by valid and fuzz.
+    Tradeable issuance with ≥2 controlled holders, modest value -> reliable tesSUCCESS."""
     tr = _tradeable(mpt_issuances)
     if not tr or not accounts:
         return None
@@ -365,10 +292,8 @@ async def _payment_mpt_valid(
     client: AsyncJsonRpcClient,
 ) -> None:
     built = _payment_mpt_base(accounts, mpt_issuances)
-    # ~30%: a cross-token best-effort routed payment (sender pays XRP via
-    # SendMax, delivers MPT through the order book). Usually tecPATH_DRY with no
-    # resting liquidity — that exercises the routing/step code; the direct path
-    # below guarantees the success bucket.
+    # ~30%: cross-token routed payment (XRP via SendMax, deliver MPT through the
+    # book). Usually tecPATH_DRY; the direct path below guarantees the success bucket.
     if built is not None and random() < 0.3:
         tr = _tradeable(mpt_issuances)
         routable = [m for m in tr if _controlled_holders(m, accounts)]
@@ -405,41 +330,34 @@ async def _payment_mpt_faulty(
     nx = _no_transfer(mpt_issuances)
     base = _payment_mpt_base(accounts, mpt_issuances)
 
-    # Conditional mutation list: include a vector only when its cohort + the
-    # accounts it needs exist. fake_mpt builds its own Payment from scratch, so
-    # it is always available; zero_amount and fuzz need a buildable base.
+    # Include a vector only when its cohort + accounts exist. fake_mpt builds its
+    # own Payment so it is always available; zero_amount/fuzz need a buildable base.
     mutations = ["fake_mpt"]
     if base is not None:
         mutations += ["zero_amount", "fuzz"]
-    # dest_not_authorized needs a tradeable MPT with a controlled holder.
     if any(_controlled_holders(m, accounts) for m in tr):
         mutations.append("dest_not_authorized")
-    # overdraw needs >=2 controlled holders so the dst is authorized and the
-    # failure is the funds check (tecPATH_PARTIAL), not the receiver auth check.
+    # overdraw needs >=2 controlled holders so dst is authorized and the failure
+    # is the funds check (tecPATH_PARTIAL), not the receiver auth check.
     if any(len(_controlled_holders(m, accounts)) >= 2 for m in tr):
         mutations.append("overdraw")
-    # no_transfer needs >=2 controlled holders (neither is the issuer by cohort).
     if any(len(_controlled_holders(m, accounts)) >= 2 for m in nx):
         mutations.append("no_transfer")
-    # locked needs >=2 controlled holders (funded pre-lock).
     if any(len(_controlled_holders(m, accounts)) >= 2 for m in lk):
         mutations.append("locked")
-    # require_auth needs the issuer (controlled) + an unauthorized non-issuer dst.
+    # require_auth needs the issuer + an unauthorized non-issuer dst.
     if any(m.issuer in accounts and len(accounts) >= 2 for m in ra):
         mutations.append("require_auth")
     mutation = choice(mutations)
 
     if mutation == "fuzz":
-        # Generative: corrupt a valid direct MPT payment in open-ended ways.
         b, wallet = base  # type: ignore[misc]
         await submit_fuzzed("PaymentMPT", b, client, wallet)
         return
 
     if mutation == "fake_mpt":
-        # Deliver a nonexistent issuance -> tecOBJECT_NOT_FOUND (requireAuth
-        # reads the issuance keylet; MPToken_test.cpp:1656,1685). fake_mpt_id is
-        # well-formed (random sequence + random issuer), not the bad-asset
-        # sentinel that would yield temBAD_CURRENCY.
+        # Deliver a nonexistent issuance -> tecOBJECT_NOT_FOUND. fake_mpt_id is
+        # well-formed, not the bad-asset sentinel that yields temBAD_CURRENCY.
         src_id, dst_id = sample(list(accounts), 2)
         src = accounts[src_id]
         txn = Payment(
@@ -451,9 +369,8 @@ async def _payment_mpt_faulty(
         return
 
     if mutation == "dest_not_authorized":
-        # Deliver a tradeable MPT to a dst that holds no MPToken -> tecNO_AUTH
-        # (requireAuth on the receiver; MPToken_test.cpp:1336-1342). src is a
-        # controlled (funded) holder of that issuance.
+        # Deliver to a dst that holds no MPToken -> tecNO_AUTH (requireAuth on
+        # the receiver). src is a controlled holder.
         usable = [m for m in tr if _controlled_holders(m, accounts)]
         mpt = choice(usable)
         holders = _controlled_holders(mpt, accounts)
@@ -471,8 +388,7 @@ async def _payment_mpt_faulty(
         return
 
     if mutation == "no_transfer":
-        # CanTransfer unset, holder->holder where neither is the issuer
-        # -> tecNO_AUTH (canTransfer; MPToken_test.cpp:1321).
+        # CanTransfer unset, holder->holder, neither the issuer -> tecNO_AUTH.
         usable = [m for m in nx if len(_controlled_holders(m, accounts)) >= 2]
         mpt = choice(usable)
         src_id, dst_id = sample(_controlled_holders(mpt, accounts), 2)
@@ -486,9 +402,8 @@ async def _payment_mpt_faulty(
         return
 
     if mutation == "locked":
-        # Globally-locked MPT, holder->holder (both funded pre-lock)
-        # -> tecPATH_DRY under MPTokensV2 (terLOCKED retry-mapped in
-        # Payment::doApply; MPToken_test.cpp:1379-1385 — NOT tecLOCKED).
+        # Globally-locked, holder->holder -> tecPATH_DRY under MPTokensV2
+        # (terLOCKED retry-mapped in Payment::doApply — NOT tecLOCKED).
         usable = [m for m in lk if len(_controlled_holders(m, accounts)) >= 2]
         mpt = choice(usable)
         src_id, dst_id = sample(_controlled_holders(mpt, accounts), 2)
@@ -502,9 +417,8 @@ async def _payment_mpt_faulty(
         return
 
     if mutation == "require_auth":
-        # Issuer delivers a require-auth MPT to a holder that was never
-        # issuer-authorized -> tecNO_AUTH (requireAuth on the receiver). Our
-        # setup never issuer-authorizes require-auth cohort holders.
+        # Issuer delivers a require-auth MPT to a never-authorized holder ->
+        # tecNO_AUTH. Setup never authorizes require-auth cohort holders.
         usable = [m for m in ra if m.issuer in accounts]
         mpt = choice(usable)
         src = accounts[mpt.issuer]
@@ -521,10 +435,8 @@ async def _payment_mpt_faulty(
         return
 
     if mutation == "overdraw":
-        # Deliver far more than the source holds, holder->holder (both authorized)
-        # -> tecPATH_PARTIAL (Payment::doApply; MPToken_test.cpp:1359-1362). The
-        # floor (>10x the 10000 setup distribution) exceeds any balance the
-        # source could plausibly accumulate from modest transfers in a session.
+        # Deliver more than the source holds (both authorized) -> tecPATH_PARTIAL.
+        # Floor >10x the setup distribution exceeds any plausible session balance.
         usable = [m for m in tr if len(_controlled_holders(m, accounts)) >= 2]
         mpt = choice(usable)
         src_id, dst_id = sample(_controlled_holders(mpt, accounts), 2)
@@ -539,10 +451,8 @@ async def _payment_mpt_faulty(
         await submit_raw("PaymentMPT", txn, client, src.wallet)
         return
 
-    # zero_amount — set the MPT Amount's value to "0" -> temBAD_AMOUNT (preflight
-    # dstAmount <= kZero; MPToken_test.cpp:1025-1029). xrpl-py accepts
-    # MPTAmount(value="0"), so the zero is injected via the raw path and
-    # rippled preflight is what rejects it. Only in the list when base is built.
+    # zero_amount — MPT Amount value "0" -> temBAD_AMOUNT. xrpl-py accepts
+    # value="0", so the zero goes via the raw path for rippled preflight to reject.
     b, wallet = base  # type: ignore[misc]
 
     def mutate_zero(d: dict) -> None:

--- a/workload/src/workload/transactions/nft.py
+++ b/workload/src/workload/transactions/nft.py
@@ -59,6 +59,7 @@ async def _nftoken_mint_faulty(
     acct_list = list(accounts.values())
     src = choice(acct_list)
     # Set issuer to another account that hasn't authorized us → tecNO_PERMISSION
+    # issuer hasn't authorized src as minter → tecNO_PERMISSION
     other = choice([a for a in acct_list if a.address != src.address])
     txn = NFTokenMint(
         account=src.address,
@@ -225,7 +226,7 @@ async def _nftoken_cancel_offer_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    # Cancel a non-existent offer → tecOBJECT_NOT_FOUND from rippled
+    # Non-existent offer → tecOBJECT_NOT_FOUND.
     txn = NFTokenCancelOffer(
         account=src.address,
         nftoken_offers=[params.fake_id()],

--- a/workload/src/workload/transactions/offers.py
+++ b/workload/src/workload/transactions/offers.py
@@ -1,7 +1,4 @@
-"""OfferCreate / OfferCancel workload handlers.
-
-Creates DEX offers that trade through AMM pools, and cancels existing offers.
-"""
+"""OfferCreate / OfferCancel workload handlers."""
 
 from __future__ import annotations
 
@@ -26,17 +23,12 @@ def _fake_iou() -> IssuedCurrency:
 
 
 def _non_mpt_amms(amms: list[AMM]) -> list[AMM]:
-    """AMMs with no MPT leg — the generic OfferCreate path trades IOU/XRP
-    pools only; MPT pools are covered by OfferCreateMPT (mpt_dex.py)."""
+    """IOU/XRP-only AMMs; MPT pools are covered by OfferCreateMPT (mpt_dex.py)."""
     return [a for a in amms if not any(isinstance(x, MPTCurrency) for x in a.assets)]
 
 
 def _random_flag() -> int:
-    """Pick a random combination of OfferCreate flags (or no flags).
-
-    XRPL allows combining flags like tfPassive | tfSell. We sample a random
-    subset and OR them together.
-    """
+    """OR together a random subset of OfferCreate flags (XRPL allows combining them)."""
     all_flags = [
         OfferCreateFlag.TF_PASSIVE,
         OfferCreateFlag.TF_SELL,
@@ -60,22 +52,17 @@ def _iou_amount(asset: IssuedCurrency, value: str) -> IOUAmount:
 def _make_offer_amounts(
     amm: AMM,
 ) -> tuple[str | IOUAmount, str | IOUAmount] | None:
-    """Build taker_gets / taker_pays from an AMM's asset pair.
-
-    Randomly picks direction: buy asset1 with asset2, or vice versa.
-    Returns (taker_gets, taker_pays) or None if assets are insufficient.
-    """
+    """Build (taker_gets, taker_pays) from an AMM pair, or None if assets insufficient."""
     if len(amm.assets) < 2:
         return None
     a1, a2 = amm.assets[0], amm.assets[1]
 
-    # Randomly pick direction
     if random() < 0.5:
         get_asset, pay_asset = a1, a2
     else:
         get_asset, pay_asset = a2, a1
 
-    # Build amounts — use small amounts to increase chance of filling
+    # Small amounts raise the chance of filling.
     if isinstance(get_asset, xrpl.models.XRP):
         taker_gets = str(randint(100_000, 10_000_000))  # 0.1-10 XRP in drops
     else:
@@ -94,7 +81,6 @@ def _find_account_for_amm(
     trust_lines: list[TrustLine],
     amm: AMM,
 ) -> UserAccount | None:
-    """Find an account that has trust lines for the AMM's IOU assets."""
     needed_ious = [a for a in amm.assets if isinstance(a, IssuedCurrency)]
     return _find_account_with_trust_lines(accounts, trust_lines, needed_ious)
 
@@ -165,7 +151,6 @@ async def _offer_create_faulty(
         ]
     )
     if mutation == "non_existent_asset":
-        # Offer with a fake IOU nobody has issued
         fake = _fake_iou()
         taker_gets = _iou_amount(fake, str(randint(1, 1_000)))
         taker_pays = str(randint(1_000_000, 100_000_000))
@@ -176,7 +161,7 @@ async def _offer_create_faulty(
         )
 
     elif mutation == "same_asset_both":
-        # Both sides are XRP (tecINSUF_RESERVE_OFFER or malformed)
+        # Both sides XRP → tecINSUF_RESERVE_OFFER or malformed.
         txn = OfferCreate(
             account=src.address,
             taker_gets=str(randint(1_000_000, 100_000_000)),
@@ -184,7 +169,6 @@ async def _offer_create_faulty(
         )
 
     elif mutation == "zero_amount":
-        # Zero taker_gets or taker_pays
         iou_amms = _non_mpt_amms(amms)
         if not iou_amms:
             return
@@ -201,7 +185,7 @@ async def _offer_create_faulty(
         )
 
     elif mutation == "negative_iou_amount":
-        # Negative IOU amount — passes xrpl-py, rejected by rippled
+        # Passes xrpl-py construction; rippled rejects it.
         iou_amms = _non_mpt_amms(amms)
         if not iou_amms:
             return
@@ -218,7 +202,6 @@ async def _offer_create_faulty(
         )
 
     else:  # crossed_offer
-        # Create an offer that crosses itself (same account, opposite direction)
         iou_amms = _non_mpt_amms(amms)
         if not iou_amms:
             return
@@ -227,7 +210,7 @@ async def _offer_create_faulty(
         if not pair:
             return
         taker_gets, taker_pays = pair
-        # Swap to create a self-crossing offer
+        # Swap sides → self-crossing offer.
         txn = OfferCreate(
             account=src.address,
             taker_gets=taker_pays,
@@ -285,17 +268,14 @@ async def _offer_cancel_faulty(
     )
 
     if mutation == "non_existent_sequence":
-        # Cancel an offer that doesn't exist
         txn = OfferCancel(
             account=src.address,
             offer_sequence=randint(900_000, 999_999),
         )
 
     else:  # cancel_others_offer
-        # Submit from src but use a sequence that likely belongs to another
-        # account. Since OfferCancel only cancels the submitter's own offers,
-        # this effectively becomes a non-existent sequence for src — exercising
-        # the "wrong owner" path from the submitter's perspective.
+        # OfferCancel only touches the submitter's own offers, so a foreign
+        # sequence is just a non-existent one from src's view.
         txn = OfferCancel(
             account=src.address,
             offer_sequence=randint(1, 100),

--- a/workload/src/workload/transactions/payment_channels.py
+++ b/workload/src/workload/transactions/payment_channels.py
@@ -1,12 +1,4 @@
-"""PaymentChannelCreate / PaymentChannelFund / PaymentChannelClaim handlers.
-
-A payment channel is a unidirectional XRP flow from source → destination.
-The source pre-funds the channel, and the destination claims from it.
-Either side can request closure subject to a settle delay.
-
-State tracking keeps (channel_id, source, destination, amount, settle_delay)
-so Fund and Claim can reference live channels.
-"""
+"""PaymentChannelCreate / PaymentChannelFund / PaymentChannelClaim handlers."""
 
 from __future__ import annotations
 
@@ -45,7 +37,6 @@ async def _channel_create_valid(
 
     acct_list = list(accounts.values())
     src = choice(acct_list)
-    # Destination must differ from source
     dst = choice([a for a in acct_list if a.address != src.address])
 
     amount = params.channel_amount()
@@ -60,10 +51,8 @@ async def _channel_create_valid(
     )
     result = await submit_tx("PaymentChannelCreate", txn, client, src.wallet)
 
-    # Optimistically track — real channel_id replaces the tx_hash placeholder
-    # via the state updater on validation.  Skip the optimistic insert when
-    # the submit response already indicates the tx won't apply, so we don't
-    # leak dead channels into Fund/Claim handlers.
+    # Track only when the submit will likely apply (state updater later swaps
+    # the tx_hash placeholder for the real channel_id), else dead channels leak.
     engine = result.get("engine_result", "") if result else ""
     if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ"):
         tx_json = result.get("tx_json", result)
@@ -157,7 +146,7 @@ async def _channel_fund_valid(
         return
 
     channel = choice(payment_channels)
-    # Only the source can fund a channel
+    # Only the source can fund a channel.
     src = accounts.get(channel.source)
     if not src:
         return
@@ -200,7 +189,7 @@ async def _channel_fund_faulty(
             channel=params.fake_id(),
             amount="0",
         )
-    else:  # non_owner_fund — random account tries to fund
+    else:  # non_owner_fund
         txn = PaymentChannelFund(
             account=src.address,
             channel=params.fake_id(),
@@ -232,7 +221,7 @@ async def _channel_claim_valid(
         return
 
     channel = choice(payment_channels)
-    # Source or destination can submit a claim
+    # Source or destination can submit a claim.
     claimer_addr = choice([channel.source, channel.destination])
     claimer = accounts.get(claimer_addr)
     if not claimer:
@@ -267,7 +256,6 @@ async def _channel_claim_faulty(
             channel=params.fake_id(),
         )
     elif mutation == "excessive_balance":
-        # Claim more than the channel holds
         txn = PaymentChannelClaim(
             account=src.address,
             channel=params.fake_id(),

--- a/workload/src/workload/transactions/payments.py
+++ b/workload/src/workload/transactions/payments.py
@@ -1,4 +1,4 @@
-"""Payment transaction generators for the antithesis workload."""
+"""Payment transaction generators."""
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models import IssuedCurrencyAmount as IOUAmount
@@ -33,7 +33,6 @@ async def _payment_random_valid(
     src_address, dst = sample(list(accounts), 2)
     src = accounts[src_address]
 
-    # Pick asset type from available options
     options = ["xrp"]
     if trust_lines:
         options.append("iou")

--- a/workload/src/workload/transactions/permissioned_dex.py
+++ b/workload/src/workload/transactions/permissioned_dex.py
@@ -1,17 +1,4 @@
-"""Permissioned DEX workload handlers (featurePermissionedDEX).
-
-Domain-restricted offers, hybrid offers, and domain-restricted payments. A
-``DomainID`` offer crosses only the domain-keyed order book; a hybrid offer
-additionally rests in the open book. Both require the submitting account to be
-a member of the domain (owner, or holder of an accepted matching credential) —
-otherwise rippled returns ``tecNO_PERMISSION``.
-
-These are registered under synthetic assertion names (OfferCreateDomain,
-OfferCreateHybrid, PaymentDomain, PaymentDomainXC); the on-ledger
-TransactionType stays OfferCreate / Payment. ws_listener fires the matching
-``tx_result`` so the success/failure buckets resolve (see the TicketUse
-precedent in ws_listener.py).
-"""
+"""Permissioned DEX handlers (featurePermissionedDEX): domain/hybrid offers and domain payments."""
 
 from __future__ import annotations
 
@@ -35,9 +22,7 @@ def _domain_members(
     accounts: dict[str, UserAccount],
     credentials: list[Credential],
 ) -> list[str]:
-    """Accounts that are members of ``domain``: the owner plus every account
-    holding an accepted credential matching one of the domain's accepted
-    (issuer, credential_type) pairs. Restricted to accounts we control."""
+    """Owner plus holders of an accepted credential matching the domain's pairs; ours only."""
     members = {domain.owner}
     accepted = set(domain.accepted_credentials)
     for c in credentials:
@@ -52,8 +37,7 @@ def _pick_domain_with_members(
     credentials: list[Credential],
     minimum: int,
 ) -> tuple[PermissionedDomain, list[str]] | None:
-    """Pick a random domain (owned by an account we control) that has at least
-    ``minimum`` members. Returns the domain and its member list, or None."""
+    """A controlled-owner domain with ≥ minimum members, plus its members; else None."""
     candidates = []
     for d in domains:
         if d.owner not in accounts:
@@ -65,7 +49,6 @@ def _pick_domain_with_members(
 
 
 def _amm_iou(amms: list[AMM]) -> IssuedCurrency | None:
-    """Pick a real gateway IOU from a random AMM's asset pair."""
     if not amms:
         return None
     amm = choice(amms)
@@ -74,8 +57,7 @@ def _amm_iou(amms: list[AMM]) -> IssuedCurrency | None:
 
 
 def _domain_offer_flags(hybrid: bool) -> int:
-    """Flags for a valid domain offer. tfPassive / tfSell still rest, so they
-    keep the success path reliable; tfHybrid is set for the hybrid bucket."""
+    """tfPassive/tfSell still rest, so they keep the success path reliable."""
     flags = int(OfferCreateFlag.TF_HYBRID) if hybrid else 0
     if random() < 0.3:
         flags |= int(OfferCreateFlag.TF_PASSIVE)
@@ -127,8 +109,7 @@ def _domain_offer_base(
     *,
     hybrid: bool,
 ) -> tuple[OfferCreate, object] | None:
-    """Build a valid domain offer (a member trades XRP for a real gateway IOU)
-    and return it with the signing wallet. Shared by the valid and fuzz paths."""
+    """Valid domain offer (member trades XRP for a gateway IOU) + wallet."""
     picked = _pick_domain_with_members(domains, accounts, credentials, minimum=1)
     if not picked:
         return None
@@ -137,8 +118,7 @@ def _domain_offer_base(
         return None
     domain, members = picked
     member = accounts[choice(members)]
-    # taker_gets = XRP (the member always has it); taker_pays = a real gateway
-    # IOU. The domain book starts empty, so the offer rests cleanly.
+    # Empty domain book, so the offer rests cleanly.
     base = OfferCreate(
         account=member.address,
         taker_gets=params.offer_xrp_drops(),
@@ -193,7 +173,6 @@ async def _domain_offer_faulty(
     mutation = choice(mutations)
 
     if mutation == "fuzz":
-        # Generative: corrupt a valid domain offer in open-ended ways.
         built = _domain_offer_base(accounts, domains, credentials, amms, hybrid=hybrid)
         if built is None:
             return
@@ -202,7 +181,7 @@ async def _domain_offer_faulty(
         return
 
     if mutation == "not_in_domain":
-        # Real domain, but submit from an account that is NOT a member -> tecNO_PERMISSION.
+        # Non-member submits to a real domain -> tecNO_PERMISSION.
         picked = _pick_domain_with_members(domains, accounts, credentials, minimum=1)
         if not picked:
             return
@@ -213,15 +192,15 @@ async def _domain_offer_faulty(
         account = accounts[choice(outsiders)]
         domain_id = domain.domain_id
     elif mutation == "fake_domain":
-        # A domain that does not exist -> tecNO_PERMISSION.
+        # Nonexistent domain -> tecNO_PERMISSION.
         account = choice(list(accounts.values()))
         domain_id = params.fake_id()
     elif mutation == "zero_domain":
-        # All-zero DomainID -> temMALFORMED (fixCleanup3_2_0) / zero-key path otherwise.
+        # temMALFORMED (fixCleanup3_2_0) / zero-key path otherwise.
         account = choice(list(accounts.values()))
         domain_id = params.zero_domain_id()
     elif mutation == "ioc_killed":
-        # Member places an IoC offer that can't cross the empty domain book -> tecKILLED.
+        # IoC offer can't cross the empty domain book -> tecKILLED.
         picked = _pick_domain_with_members(domains, accounts, credentials, minimum=1)
         if not picked:
             return
@@ -229,7 +208,7 @@ async def _domain_offer_faulty(
         account = accounts[choice(members)]
         domain_id = domain.domain_id
         flags |= int(OfferCreateFlag.TF_IMMEDIATE_OR_CANCEL)
-    else:  # hybrid_no_domain — strip DomainID from a valid hybrid base -> temINVALID_FLAG.
+    else:  # hybrid_no_domain — tfHybrid without DomainID -> temINVALID_FLAG.
         picked = _pick_domain_with_members(domains, accounts, credentials, minimum=1)
         domain_id = picked[0].domain_id if picked else params.fake_id()
         account = choice(list(accounts.values()))
@@ -266,8 +245,7 @@ def _domain_payment_base(
     domains: list[PermissionedDomain],
     credentials: list[Credential],
 ) -> tuple[Payment, object] | None:
-    """Build a valid direct XRP domain payment between two members + its wallet.
-    Shared by the valid and fuzz paths (both parties must be in-domain)."""
+    """Direct XRP payment between two in-domain members + wallet; shared by valid and fuzz."""
     picked = _pick_domain_with_members(domains, accounts, credentials, minimum=2)
     if not picked:
         return None
@@ -307,7 +285,6 @@ async def _payment_domain_faulty(
 
     mutation = choice(["outsider_party", "fake_domain", "zero_domain", "fuzz"])
     if mutation == "fuzz":
-        # Generative: corrupt a valid domain payment in open-ended ways.
         built = _domain_payment_base(accounts, domains, credentials)
         if built is None:
             return
@@ -315,7 +292,7 @@ async def _payment_domain_faulty(
         await submit_fuzzed("PaymentDomain", base, client, wallet)
         return
     if mutation == "outsider_party":
-        # One in-domain member + one outsider -> tecNO_PERMISSION.
+        # One member + one outsider -> tecNO_PERMISSION.
         picked = _pick_domain_with_members(domains, accounts, credentials, minimum=1)
         if not picked:
             return
@@ -327,11 +304,11 @@ async def _payment_domain_faulty(
         dst_id = choice(outsiders)
         domain_id = domain.domain_id
     elif mutation == "fake_domain":
-        # Neither party can be in a domain that does not exist -> tecNO_PERMISSION.
+        # Nonexistent domain -> tecNO_PERMISSION.
         src_id, dst_id = sample(list(accounts), 2)
         src = accounts[src_id]
         domain_id = params.fake_id()
-    else:  # zero_domain — all-zero DomainID -> temMALFORMED / zero-key path
+    else:  # zero_domain — temMALFORMED / zero-key path
         src_id, dst_id = sample(list(accounts), 2)
         src = accounts[src_id]
         domain_id = params.zero_domain_id()
@@ -355,12 +332,8 @@ async def payment_domain_xc(
     amms: list[AMM],
     client: AsyncJsonRpcClient,
 ) -> None:
-    """Cross-currency Payment + DomainID — exercises domain pathfinding (routing
-    through the domain order book). Success requires resting domain liquidity in
-    the matching direction, which is not guaranteed here, so PaymentDomainXC is
-    listed in assertions._NO_SUCCESS_TYPES; the common result is a tec failure
-    (tecPATH_DRY / tecNO_PERMISSION), which still satisfies the failure bucket
-    and exercises the both-parties-in-domain preclaim + pathfinding code."""
+    """Cross-currency Payment + DomainID for domain pathfinding. No guaranteed liquidity, so
+    success is unreliable (in _NO_SUCCESS_TYPES); usual result is a tec failure."""
     if not amms:
         return
     picked = _pick_domain_with_members(domains, accounts, credentials, minimum=2)
@@ -372,8 +345,7 @@ async def payment_domain_xc(
     domain, members = picked
     src_id, dst_id = sample(members, 2)
     src = accounts[src_id]
-    # Sender pays XRP (always fundable) via SendMax; deliver a small IOU amount
-    # to the destination, routed through the domain book.
+    # Sender pays XRP via SendMax; deliver an IOU routed through the domain book.
     deliver = IOUAmount(currency=iou.currency, issuer=iou.issuer, value=params.offer_iou_value())
     txn = Payment(
         account=src.address,

--- a/workload/src/workload/transactions/set_regular_key.py
+++ b/workload/src/workload/transactions/set_regular_key.py
@@ -1,9 +1,4 @@
-"""SetRegularKey workload handler.
-
-SetRegularKey assigns or removes a regular key pair for an account.
-When set, both the master key and the regular key can sign transactions.
-Setting regular_key to None removes it.
-"""
+"""SetRegularKey handler; omitting regular_key removes it."""
 
 from __future__ import annotations
 
@@ -35,18 +30,15 @@ async def _set_regular_key_valid(
     acct_list = list(accounts.values())
     src = choice(acct_list)
 
-    # Randomly set or remove the regular key
     action = choice(["set", "remove"])
 
     if action == "set":
-        # Pick another account's address as the regular key
         dst = choice([a for a in acct_list if a.address != src.address])
         txn = SetRegularKey(
             account=src.address,
             regular_key=dst.address,
         )
     else:
-        # Remove regular key
         txn = SetRegularKey(
             account=src.address,
         )

--- a/workload/src/workload/transactions/signer_list_set.py
+++ b/workload/src/workload/transactions/signer_list_set.py
@@ -1,12 +1,4 @@
-"""SignerListSet workload handler.
-
-SignerListSet configures multi-signing on an account.  A signer list
-defines which accounts can co-sign transactions and the quorum needed.
-Setting signer_quorum=0 with no entries deletes the list.
-
-This is a NON_DELEGABLE transaction — delegation is blocked by the
-XRPL protocol itself.
-"""
+"""SignerListSet handler (NON_DELEGABLE): signer_quorum=0 with no entries deletes the list."""
 
 from __future__ import annotations
 
@@ -42,7 +34,6 @@ async def _signer_list_set_valid(
     action = choice(["set", "remove"])
 
     if action == "set":
-        # Pick 2-5 unique signers (not self)
         others = [a for a in acct_list if a.address != src.address]
         count = min(randint(2, 5), len(others))
         signers = sample(others, count)
@@ -64,7 +55,6 @@ async def _signer_list_set_valid(
             signer_entries=entries,
         )
     else:
-        # Delete the signer list
         txn = SignerListSet(
             account=src.address,
             signer_quorum=0,
@@ -90,7 +80,6 @@ async def _signer_list_set_faulty(
     )
 
     if mutation == "fake_signers":
-        # Many non-existent signer accounts
         count = randint(2, 8)
         entries = [
             SignerEntry(account=params.fake_account(), signer_weight=1) for _ in range(count)
@@ -109,7 +98,6 @@ async def _signer_list_set_faulty(
             ],
         )
     else:  # high_quorum_fake_signers
-        # Quorum equals total weight — hard to meet
         count = randint(3, 8)
         entries = [
             SignerEntry(account=params.fake_account(), signer_weight=1) for _ in range(count)

--- a/workload/src/workload/transactions/tickets.py
+++ b/workload/src/workload/transactions/tickets.py
@@ -36,18 +36,13 @@ from workload.submit import submit_tx
 from workload.transactions.permissioned_dex import _amm_iou, _domain_members
 
 # ── Ticket-eligible transaction builders ─────────────────────────────
-# Each builder takes a TicketCtx and returns a Transaction (or None to skip
-# when its preconditions aren't met). ``ctx.common`` already contains
-# account, sequence=0, ticket_sequence=N. State-aware builders (permissioned
-# DEX) read ctx.domains/credentials/amms; simple ones use only ctx.dst.
-# To add a new type: add one entry to this dict (or to _TICKET_EXCLUDED).
+# Each builder takes a TicketCtx and returns a Transaction or None (skip when
+# preconditions unmet). Add a new type here or to _TICKET_EXCLUDED.
 
 
 @dataclass
 class TicketCtx:
-    """Context for a ticket builder: the ticket-holding ``src`` account, a
-    random ``dst``, the ``common`` fields (account / sequence=0 /
-    ticket_sequence), and workload state for builders needing existing objects."""
+    """Passed to a ticket builder; ``common`` carries sequence=0 + ticket_sequence."""
 
     src: UserAccount
     dst: str
@@ -67,8 +62,7 @@ def _ticket_domain_offer(ctx: TicketCtx, *, hybrid: bool) -> "xrpl.models.Transa
     iou = _amm_iou(ctx.amms)
     if iou is None:
         return None
-    # Prefer a domain the src is a member of (offer rests → tesSUCCESS); else any
-    # domain (src not a member → tecNO_PERMISSION). Both exercise ticket x domain.
+    # Prefer a domain src belongs to (offer rests) else any domain (tecNO_PERMISSION).
     member_domains = [
         d
         for d in ctx.domains
@@ -90,8 +84,7 @@ def _ticket_domain_offer(ctx: TicketCtx, *, hybrid: bool) -> "xrpl.models.Transa
 def _ticket_domain_payment(
     ctx: TicketCtx, *, cross_currency: bool
 ) -> "xrpl.models.Transaction | None":
-    # Need a domain the src is a member of; pick a co-member as destination so the
-    # both-parties-in-domain preclaim can pass (else tecNO_PERMISSION).
+    # Both parties must be domain members or preclaim fails (tecNO_PERMISSION).
     member_domains = []
     for d in ctx.domains:
         members = _domain_members(d, ctx.accounts, ctx.credentials)
@@ -129,8 +122,7 @@ _TICKET_BUILDERS: dict[str, _TicketBuilder] = {
         amount=params.payment_amount(),
         **ctx.common,
     ),
-    # dst as credential issuer is intentional — exercises the domain with an
-    # arbitrary issuer so ticket-derived keylets get the coverage we need.
+    # dst as credential issuer is intentional — arbitrary issuer covers ticket keylets.
     "PermissionedDomainSet": lambda ctx: PermissionedDomainSet(
         accepted_credentials=[
             XRPLCredential(issuer=ctx.dst, credential_type=params.credential_type()),
@@ -185,30 +177,20 @@ _TICKET_BUILDERS: dict[str, _TicketBuilder] = {
         **ctx.common,
     ),
     "DIDSet": lambda ctx: DIDSet(uri=params.did_hex_field(), **ctx.common),
-    # Permissioned DEX x tickets — exercise ticket consumption together with the
-    # domain preclaim / hybrid placement. State-aware (reads ctx.domains/amms).
+    # Permissioned DEX x tickets — state-aware (reads ctx.domains/amms).
     "OfferCreateDomain": lambda ctx: _ticket_domain_offer(ctx, hybrid=False),
     "OfferCreateHybrid": lambda ctx: _ticket_domain_offer(ctx, hybrid=True),
     "PaymentDomain": lambda ctx: _ticket_domain_payment(ctx, cross_currency=False),
     "PaymentDomainXC": lambda ctx: _ticket_domain_payment(ctx, cross_currency=True),
 }
 
-# Types explicitly excluded from ticket use.  Reasons:
-#   "objects"  — requires pre-existing object IDs (vault_id, nft, offer, etc.)
-#   "circular" — tickets creating/using tickets
-#   "cosign"   — requires multi-party signing
-#   "batch"    — outer batch manages inner sequences
-# Adding a new REGISTRY type without a builder or exclusion triggers a
-# startup warning so new types can't silently skip ticket coverage.
+# Types the (dst, common)-only builder signature can't reach: objects (need
+# pre-existing IDs), circular (tickets on tickets), cosign, batch.
 _TICKET_EXCLUDED: set[str] = {
-    # circular — tickets creating/using tickets
     "TicketCreate",
     "TicketUse",
-    # batch — outer batch manages inner sequences
     "Batch",
-    # cosign — requires multi-party signing
     "LoanSet",
-    # objects — requires pre-existing object IDs
     "NFTokenBurn",
     "NFTokenModify",
     "NFTokenCreateOffer",
@@ -240,8 +222,6 @@ _TICKET_EXCLUDED: set[str] = {
     "EscrowCancel",
     "PaymentChannelFund",
     "PaymentChannelClaim",
-    # All AMM and Offer types need asset-pair / existing-object state
-    # that the (dst, common)-only builder signature can't reach.
     "AMMCreate",
     "AMMDeposit",
     "AMMWithdraw",
@@ -250,31 +230,17 @@ _TICKET_EXCLUDED: set[str] = {
     "AMMDelete",
     "OfferCreate",
     "OfferCancel",
-    # OfferCreateMPT needs MPT-issuance state the (dst, common)-only builder
-    # can't reach — same rationale as OfferCreate / AMMCreate above.
     "OfferCreateMPT",
-    # PaymentMPT needs MPT-issuance/holder state the (dst, common)-only builder
-    # can't reach — same rationale as OfferCreateMPT.
     "PaymentMPT",
-    # PaymentChannelCreate needs public_key from the wallet, which the
-    # (dst, common)-only builder signature can't reach.
-    "PaymentChannelCreate",
-    # Clawback requires the source to be an authorised issuer.
-    "Clawback",
+    "PaymentChannelCreate",  # needs public_key from the wallet
+    "Clawback",  # source must be an authorised issuer
     "AccountDelete",
-    # objects — needs an existing DID on the account
     "DIDDelete",
 }
 
 
 def check_ticket_coverage() -> None:
-    """Assert at startup that every REGISTRY type is covered.
-
-    Called during app init.  Compares REGISTRY against _TICKET_BUILDERS
-    and _TICKET_EXCLUDED so new types can't silently skip ticket coverage.
-    Missing types fire an ``unreachable`` assertion that surfaces in
-    Antithesis triage.
-    """
+    """Fire ``unreachable`` for any REGISTRY type missing from both builders and exclusions."""
     from antithesis.assertions import unreachable
 
     from workload.transactions import TX_TYPES
@@ -338,19 +304,16 @@ async def _ticket_use_valid(
     amms: list[AMM],
     client: AsyncJsonRpcClient,
 ) -> None:
-    # Find an account with tickets
     accounts_with_tickets = [(addr, acc) for addr, acc in accounts.items() if acc.tickets]
     if not accounts_with_tickets:
         return
     src_addr, src = choice(accounts_with_tickets)
     ticket_sequence = choice(list(src.tickets))
-    # Pick a destination that isn't the source
     other_accounts = [a for a in accounts if a != src_addr]
     if not other_accounts:
         return
     dst = choice(other_accounts)
 
-    # Randomly pick a ticket-eligible transaction type
     tx_type = choice(list(_TICKET_BUILDERS))
     common = {"account": src.address, "sequence": 0, "ticket_sequence": ticket_sequence}
     ctx = TicketCtx(
@@ -366,10 +329,9 @@ async def _ticket_use_valid(
     if txn is None:
         return  # state-aware builder couldn't satisfy preconditions this round
 
-    # Remove ticket optimistically to avoid reuse by concurrent calls
+    # Optimistic discard avoids reuse by concurrent calls.
     src.tickets.discard(ticket_sequence)
-    # Hit the TicketUse reachability assertion separately — submit_tx uses
-    # the inner type so success/failure track the real TransactionType.
+    # Separate TicketUse assertion — submit_tx tracks success/failure on the inner type.
     tx_submitted("TicketUse", txn)
     await submit_tx(tx_type, txn, client, src.wallet)
 

--- a/workload/src/workload/transactions/trustlines.py
+++ b/workload/src/workload/transactions/trustlines.py
@@ -1,10 +1,4 @@
-"""Trust line transaction generators for the antithesis workload.
-
-A trust line (RippleState) is a symmetric relationship between two accounts
-for a specific currency. Either side can create it via TrustSet. The currency
-is identified as (currency_code, issuer_address) where "issuer" is contextual —
-if account A holds USD.B, then B is the issuer from A's perspective.
-"""
+"""Trust line generators; "issuer" is contextual — if A holds USD.B, B is issuer from A's view."""
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models import IssuedCurrencyAmount as IOUAmount
@@ -32,7 +26,6 @@ async def _trustline_create_valid(
     account_id, other_id = sample(list(accounts), 2)
     account = accounts[account_id]
     currency = params.currency_code()
-    # The submitter sets a trust line limit for currency issued by the other account
     txn = TrustSet(
         account=account.address,
         limit_amount=IOUAmount(

--- a/workload/src/workload/transactions/vaults.py
+++ b/workload/src/workload/transactions/vaults.py
@@ -24,7 +24,6 @@ from workload.submit import submit_tx
 
 
 def _amount_for_asset(asset: object) -> IOUAmount | MPTAmount | str:
-    """Create an Amount matching the vault's asset type."""
     if isinstance(asset, IssuedCurrency):
         return IOUAmount(
             currency=asset.currency,
@@ -36,14 +35,12 @@ def _amount_for_asset(asset: object) -> IOUAmount | MPTAmount | str:
             mpt_issuance_id=asset.mpt_issuance_id,
             value=params.mpt_amount(),
         )
-    # XRP — return drops as string
     return params.vault_deposit_amount()
 
 
 def _random_asset(
     trust_lines: list[TrustLine], mpt_issuances: list[MPTokenIssuance]
 ) -> IssuedCurrency | MPTCurrency | xrpl.models.XRP:
-    """Pick a random asset: XRP, IOU, or MPT based on available state."""
     roll = random()
     if trust_lines and roll < 0.33:
         tl = choice(trust_lines)
@@ -184,10 +181,8 @@ async def _vault_deposit_faulty(
             return
         vault = choice(vaults)
         if isinstance(vault.asset, xrpl.models.XRP):
-            # Vault is XRP, deposit IOU instead
             amount = IOUAmount(currency="USD", issuer=depositor.address, value=params.iou_amount())
         else:
-            # Vault is IOU/MPT, deposit XRP drops instead
             amount = params.vault_deposit_amount()
         txn = VaultDeposit(
             account=depositor.address,
@@ -209,7 +204,6 @@ async def vault_withdraw(
 
 
 def _state_aware_withdraw_amount(vault: Vault) -> IOUAmount | MPTAmount | str:
-    """Generate a withdraw amount informed by tracked vault balance."""
     if vault.balance <= 0:
         return _amount_for_asset(vault.asset)
     strategy = choice(["exact", "half", "small"])
@@ -361,7 +355,7 @@ async def _vault_delete_valid(
 ) -> None:
     if not vaults:
         return
-    # Prefer vaults with zero balance — non-empty vaults return tecNO_PERMISSION
+    # Non-empty vaults return tecNO_PERMISSION
     empty = [v for v in vaults if v.balance <= 0 and v.owner in accounts]
     vault = choice(empty) if empty else choice(vaults)
     if vault.owner not in accounts:
@@ -414,13 +408,11 @@ async def vault_clawback(
 
 
 def _get_asset_issuer(vault: Vault) -> str | None:
-    """Return the issuer address for the vault's asset, or None for XRP."""
+    """Issuer address for the vault's asset, or None for XRP."""
     if isinstance(vault.asset, IssuedCurrency):
         return vault.asset.issuer
     if isinstance(vault.asset, MPTCurrency):
-        # MPT issuance ID encodes the issuer — but we need the address.
-        # The issuer is stored in the MPTokenIssuance model, but we don't have
-        # that here. For now, return None and let the caller skip.
+        # MPT issuer address not reachable from the issuance ID here; skip.
         return None
     return None
 
@@ -431,14 +423,12 @@ async def _vault_clawback_valid(
     if not vaults:
         return
     # VaultClawback must be submitted by the asset issuer, not the vault owner.
-    # Filter to IOU vaults where the issuer is known and shareholders exist.
     eligible = [v for v in vaults if _get_asset_issuer(v) in accounts and v.shareholders]
     if not eligible:
         return
     vault = choice(eligible)
     issuer_address = _get_asset_issuer(vault)
     issuer = accounts[issuer_address]
-    # Pick a known shareholder (someone who actually deposited)
     holder = choice(list(vault.shareholders))
     txn = VaultClawback(
         account=issuer.address,
@@ -470,7 +460,7 @@ async def _vault_clawback_faulty(
             holder=holder,
             amount=_amount_for_asset(vault.asset),
         )
-    else:  # clawback_self — owner == holder
+    else:  # clawback_self
         txn = VaultClawback(
             account=owner.address,
             vault_id=vault.vault_id,

--- a/workload/src/workload/ws_listener.py
+++ b/workload/src/workload/ws_listener.py
@@ -1,11 +1,4 @@
-"""WebSocket transaction observer.
-
-Subscribes to the xrpld transactions stream and processes all validated
-transaction results. Fires Antithesis assertions and updates workload
-state (vaults, NFTs, etc.) from the validated metadata.
-
-State updaters are defined in transactions/__init__.py (the registry).
-"""
+"""WebSocket transaction observer: fires assertions and updates state from validated tx metadata."""
 
 from __future__ import annotations
 
@@ -30,22 +23,15 @@ _TF_HYBRID = 0x00100000  # OfferCreateFlag.TF_HYBRID
 
 
 def _amount_is_mpt(amt: object) -> bool:
-    """True when an amount field is an MPT amount object."""
     return isinstance(amt, dict) and "mpt_issuance_id" in amt
 
 
 def _delivered_amount(tx: dict) -> object:
-    """A validated Payment's delivered amount.
-
-    api_version 2 renames the Payment ``Amount`` field to ``DeliverMax`` (and
-    drops ``Amount`` from the response/stream JSON), so read ``DeliverMax`` with
-    an ``Amount`` fallback for api_version 1. The workload's WS stream is
-    api_version 2, so a Payment here has ``DeliverMax``, never ``Amount``."""
+    """api_version 2 renames Payment Amount→DeliverMax and drops Amount; fall back for v1."""
     return tx.get("DeliverMax", tx.get("Amount"))
 
 
 def _handle_validated_tx(workload: Workload, msg: dict) -> None:
-    """Process a single validated transaction from the WS stream."""
     meta = msg.get("meta", {})
     tx = msg.get("tx_json", {})
     tx_type = tx.get("TransactionType", "")
@@ -53,15 +39,11 @@ def _handle_validated_tx(workload: Workload, msg: dict) -> None:
     tx_hash = msg.get("hash", "")
     account = tx.get("Account", "")
 
-    # Only process transactions from our accounts
     if account not in workload.accounts:
         return
 
-    # Inner batch transactions are top-level entries in the closed ledger
-    # txMap (rippled rawTxInsert's them during apply). They arrive here
-    # alongside their outer Batch. Emit a dedicated event so they can be
-    # grepped from the events stream, then fall through so state updaters
-    # still see the side effects (e.g. minted NFTs from inner NFTokenMint).
+    # Inner batch txns arrive as top-level entries alongside their outer Batch.
+    # Tag them, then fall through so state updaters still see the side effects.
     if tx.get("Flags", 0) & _TF_INNER_BATCH_TXN:
         send_event(
             "workload::inner_batch_observed",
@@ -75,7 +57,6 @@ def _handle_validated_tx(workload: Workload, msg: dict) -> None:
             },
         )
 
-    # Build a normalized result dict for tx_result()
     result = {
         "engine_result": engine_result,
         "engine_result_message": "",
@@ -85,41 +66,31 @@ def _handle_validated_tx(workload: Workload, msg: dict) -> None:
     }
     tx_result(tx_type, result)
 
-    # Any transaction carrying a TicketSequence is a TicketUse — emit that bucket
-    # too (the workload drives many tx types through the ticket path, not just
-    # Payment). Inner batch txns are tagged above and handled separately.
+    # TicketSequence ⇒ TicketUse bucket: many tx types drive the ticket path, not just Payment.
     if tx.get("TicketSequence") is not None:
         tx_result("TicketUse", result)
 
-    # Permissioned-DEX variants carry a DomainID. Fire their dedicated result
-    # bucket so the synthetic-name assertions (registered from REGISTRY) resolve.
+    # DomainID ⇒ synthetic permissioned-DEX buckets so REGISTRY synthetic-name assertions resolve.
     if tx_type == "OfferCreate" and tx.get("DomainID"):
         is_hybrid = bool(tx.get("Flags", 0) & _TF_HYBRID)
         tx_result("OfferCreateHybrid" if is_hybrid else "OfferCreateDomain", result)
     elif tx_type == "Payment" and tx.get("DomainID"):
-        # Non-XRP delivery (delivered amount is an object) or a SendMax means
-        # cross-currency. Read DeliverMax (api_version 2 renames Amount).
+        # SendMax or non-string delivered amount ⇒ cross-currency (api_version 2 renames Amount).
         is_xc = tx.get("SendMax") is not None or not isinstance(_delivered_amount(tx), str)
         tx_result("PaymentDomainXC" if is_xc else "PaymentDomain", result)
 
-    # MPT-on-DEX (XLS-82): an OfferCreate with an MPT leg. Independent of the
-    # DomainID block above — a pure MPT offer carries no DomainID, so this never
-    # double-fires with the domain buckets.
+    # MPT-on-DEX (XLS-82): pure MPT offer has no DomainID, so never double-fires domain buckets.
     if tx_type == "OfferCreate" and (
         _amount_is_mpt(tx.get("TakerGets")) or _amount_is_mpt(tx.get("TakerPays"))
     ):
         tx_result("OfferCreateMPT", result)
 
-    # MPT-on-DEX (XLS-82): a Payment carrying an MPT (in Amount or SendMax).
-    # Independent of the DomainID block above. Also catches the generic Payment
-    # handler's MPT sends — intentional: any MPT-bearing payment feeds the
-    # PaymentMPT buckets.
+    # MPT-on-DEX (XLS-82): any MPT-bearing payment (Amount or SendMax) feeds PaymentMPT.
     if tx_type == "Payment" and (
         _amount_is_mpt(_delivered_amount(tx)) or _amount_is_mpt(tx.get("SendMax"))
     ):
         tx_result("PaymentMPT", result)
 
-    # Update state on success
     if engine_result == "tesSUCCESS":
         updater = STATE_UPDATERS.get(tx_type)
         if updater:
@@ -130,10 +101,7 @@ def _handle_validated_tx(workload: Workload, msg: dict) -> None:
 
 
 async def start_ws_listener(workload: Workload, ws_url: str) -> None:
-    """Subscribe to validated transactions and process results.
-
-    Runs forever with automatic reconnection. Start as a background task.
-    """
+    """Run forever with auto-reconnect; start as a background task."""
     while True:
         try:
             async with AsyncWebsocketClient(ws_url) as ws:


### PR DESCRIPTION
Cut WHAT prose from code (kept WHY/contracts) and tightened CLAUDE.md + .claude docs; logic unchanged (AST-verified), ruff + check-imports/check-endpoints pass.