### PR TITLE
Add Zed pyright venv config and ignore .direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ xrpld.log
 __pycache__/
 *.py[cod]
 .venv/
+.direnv/
 uv.lock
 pip-log.txt
 logs

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,16 @@
+{
+  "languages": {
+    "Python": {
+      "language_servers": ["pyright", "ruff"]
+    }
+  },
+  "lsp": {
+    "pyright": {
+      "settings": {
+        "python": {
+          "pythonPath": "workload/.venv/bin/python"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Points Zed's pyright at `workload/.venv/bin/python` (relative, so each worktree resolves its own venv) and ignores the `.direnv/` cache. Committed so all worktrees get import resolution without per-folder setup.