### PR TITLE
Resolve venv deps in basedpyright via pyrightconfig

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,16 +1,7 @@
 {
   "languages": {
     "Python": {
-      "language_servers": ["pyright", "ruff"]
-    }
-  },
-  "lsp": {
-    "pyright": {
-      "settings": {
-        "python": {
-          "pythonPath": "workload/.venv/bin/python"
-        }
-      }
+      "language_servers": ["basedpyright", "ruff"]
     }
   }
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+  "venvPath": "workload",
+  "venv": ".venv",
+  "typeCheckingMode": "standard"
+}


### PR DESCRIPTION
Zed's default Python LSP is now basedpyright, which ignored the `.zed` `pythonPath` so `xrpl`/`antithesis` and all venv deps showed `reportMissingImports`.

- Add `pyrightconfig.json` (`venvPath`/`venv` → `workload/.venv`) so basedpyright/pyright find the venv in any editor + CI.
- `typeCheckingMode: standard` (upstream default) — mypy stays the strict gate. Drops noise 391 err / 2082 warn → 66 err / 0 warn.
- `.zed/settings.json`: select basedpyright + ruff; drop the unused `pythonPath` block.