### PR TITLE
Wire generative fuzzing into every transaction _faulty handler

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
-      - name: imports + endpoints
-        run: nix develop --command bash -c "scripts/check-imports && scripts/check-endpoints"
+      - name: imports + endpoints + fuzz coverage
+        run: nix develop --command bash -c "scripts/check-imports && scripts/check-endpoints && scripts/check-fuzz-coverage"
       - name: lint + types
         run: |
           nix develop --command bash -c "cd workload && \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,15 @@ Antithesis workload generator for rippled fuzzing. FastAPI server emits random X
 `direnv allow` once — `.envrc` auto-loads the flake devshell (Python, uv, ruff, mypy, basedpyright, `scripts/` on PATH) on every `cd` into the tree, and `uv sync`s the venv. Without direnv, prefix commands with `nix develop --command` (what CI does). With the env active:
 
 ```bash
-check-imports      # imports resolve (~2s)
-check-endpoints    # endpoints register (~3s)
+check-imports        # imports resolve (~2s)
+check-endpoints      # endpoints register (~3s)
+check-fuzz-coverage  # every _faulty wires generative fuzz (~2s)
 ```
 
 ## Add a transaction type
 
 1. `params.py` — parameter generators for every randomizable field.
-2. `transactions/<name>.py` — dispatch + `_valid` + `_faulty`:
+2. `transactions/<name>.py` — dispatch + `_valid` + `_faulty`, sharing a `_<name>_base()` builder. `_faulty` MUST include a `"fuzz"` choice (see Generative fuzzing) plus ≥1 curated tec vector:
    ```python
    async def escrow_create(accounts, escrows, client):
        if params.should_send_faulty():
@@ -28,7 +29,7 @@ check-endpoints    # endpoints register (~3s)
 7. `scripts/check-endpoints` — add the endpoint path to `expected`.
 8. `transactions/tickets.py` — classify in `_TICKET_BUILDERS` or `_TICKET_EXCLUDED`. Builders take a `TicketCtx` (src/dst, `common`, workload state) and return a `Transaction` or `None`. Only types that can't be built from the ctx (need object IDs, cosign, circular, batch) go in `_TICKET_EXCLUDED`. Every `REGISTRY` type must be in one; else `check_ticket_coverage` fires `unreachable : ticket_coverage_missing`.
 9. `setup.py` — creation logic if other transactions depend on the object.
-10. Run `check-imports` and `check-endpoints`.
+10. Run `check-imports`, `check-endpoints`, and `check-fuzz-coverage`.
 
 ## Patterns
 
@@ -53,10 +54,12 @@ Return early silently on empty state — never raise, never log. Non-XRPL except
 ### Faulty handlers
 One random mutation via `choice()`; never raise; same preconditions as `_valid`. Mutations: `fake_id()`, `zero_domain_id()` (→ `temMALFORMED`), non-owner submit, zero/negative amounts, mismatched assets, overdraw. Keep overdraw/state-aware mutations out of `_valid`.
 
-`tem*`/`tef*` vectors never enter a ledger, so they feed only `seen` + the submit-time `no_internal_rippled_error_submit` check — NOT the `success`/`failure` buckets. Keep ≥1 tec-producing vector per `_faulty` or `sometimes(failure)` starves.
+`tem*`/`tef*` vectors never enter a ledger, so they feed only `seen` + the submit-time `no_internal_rippled_error_submit` check — NOT the `success`/`failure` buckets. Keep ≥1 tec-producing vector per `_faulty` or `sometimes(failure)` starves. When no tec is reachable (e.g. malformations are all tem, or the "fault" is a tesSUCCESS no-op), add the type to `assertions._NO_FAILURE_TYPES` with a one-line reason instead.
 
 ### Generative fuzzing (`fuzz.py`)
-`submit_fuzzed(name, base, client, wallet)` applies 1–3 type-inferred mutations to a valid base's dict (boundary/zero/max, hostile hashes/accounts, empty/oversize/duplicate arrays, field drops), keeping it encodable and signed so it reaches preflight/preclaim/doApply. Leaves auth/sequence/fee intact (`_PROTECTED`). Rides `submit_raw`; emits `workload::fuzz` (+ `workload::fuzz_skipped`). Wired as one `"fuzz"` choice alongside curated mutations (share a `_*_base()` builder).
+`submit_fuzzed(name, base, client, wallet)` applies 1–3 type-inferred mutations to a valid base's dict (boundary/zero/max, hostile hashes/accounts, empty/oversize/duplicate arrays, field drops), keeping it encodable and signed so it reaches preflight/preclaim/doApply. Leaves auth/sequence/fee intact (`_PROTECTED`). Rides `submit_raw`; emits `workload::fuzz` (+ `workload::fuzz_skipped`).
+
+Wired as one `"fuzz"` choice in **every** `_faulty`, alongside curated mutations sharing a `_*_base()` builder — `check-fuzz-coverage` fails CI for any `_faulty` lacking it. Because fuzz rides single-wallet `submit_raw`, it can't sign txns needing a counterparty co-sign: `LoanSet` (broker co-sign) is the sole exclusion, listed in `check-fuzz-coverage`. `Batch` is single-account so it fuzzes the outer dict; multi-account batches would need `BatchSigners`.
 
 ### LoanSet co-signing
 Dual sign (borrower + broker): `autofill_and_sign` → `sign_loan_set_by_counterparty` → `xrpl_submit`, then `tx_submitted("LoanSet", txn, result)`. Setup direct paths (`setup.py` co-sign, `_probe_node`) call `assert_no_internal_error_submit` and emit `setup_*` instead.

--- a/scripts/check-fuzz-coverage
+++ b/scripts/check-fuzz-coverage
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/../workload"
+
+echo "Checking generative-fuzz coverage of _faulty handlers..."
+uv run python -c "
+import ast
+import pathlib
+
+# Faulty handlers that legitimately cannot ride submit_fuzzed (which single-signs
+# via submit_raw). Keep this set tiny and justified.
+EXCLUDED = {
+    '_loan_set_faulty',  # LoanSet dual co-signs; a single-wallet fuzz only hits auth rejects.
+}
+
+tx_dir = pathlib.Path('src/workload/transactions')
+missing: list[str] = []
+for path in sorted(tx_dir.glob('*.py')):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or not node.name.endswith('_faulty'):
+            continue
+        if node.name in EXCLUDED:
+            continue
+        calls = {
+            n.func.id
+            for n in ast.walk(node)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+        if 'submit_fuzzed' not in calls:
+            missing.append(f'{path.name}::{node.name}')
+
+if missing:
+    print(f'FAILED: {len(missing)} _faulty handler(s) missing a submit_fuzzed branch:')
+    for m in missing:
+        print(f'  {m}')
+    print('Add a \"fuzz\" choice (see CLAUDE.md) or, if it cannot be fuzzed, add it to EXCLUDED.')
+    exit(1)
+print('All _faulty handlers wire generative fuzz OK')
+"

--- a/workload/src/workload/assertions.py
+++ b/workload/src/workload/assertions.py
@@ -20,14 +20,28 @@ _RIPPLED_INTERNAL_ERRORS = (
     "tecINVARIANT_FAILED",
 )
 
-# Types whose faulty handler never produces a non-tesSUCCESS, so failure can't
-# be met:
-# - SignerListSet: fake AccountIDs accepted (rippled doesn't verify listed
-#   accounts exist); mutations stay within weight bounds.
-# - MPTokenIssuanceCreate: no _faulty handler — always a valid create.
+# Types whose faulty handler never reliably produces a tec. The failure bucket is
+# fed only by ledger-entering results, so tem*/tef* (preflight) and tesSUCCESS
+# no-ops don't satisfy it — they feed seen + the submit-time internal-error check.
+# Generative fuzz mostly yields tem*/tef*, so it doesn't lift these out of the set.
+# - SignerListSet: fake AccountIDs are accepted as phantom accounts; quorum/weights
+#   stay in bounds, so every curated vector reaches tesSUCCESS.
+# - MPTokenIssuanceCreate: a fresh issuance from a funded account succeeds; curated
+#   vectors + fuzz are tem-only (the reserve/dir tecs need an exhausted account).
+# - AccountSet: every malformation is preflight tem (bad TransferRate/TickSize,
+#   set==clear flag); the lone tec (tecNO_PERMISSION) comes from OTHER txns.
+# - SetRegularKey: self-key is temBAD_REGKEY; a fake (unfunded) key just succeeds.
+# - TrustSet: self-trust is temDST_IS_SRC; no tec is reachable with funded accounts.
+# - TicketCreate: bad count is temINVALID_COUNT; reserve tecs need an exhausted account.
+# - NFTokenCancelOffer: canceling an unknown offer id is a tesSUCCESS no-op.
 _NO_FAILURE_TYPES = {
     "SignerListSet",
     "MPTokenIssuanceCreate",
+    "AccountSet",
+    "SetRegularKey",
+    "TrustSet",
+    "TicketCreate",
+    "NFTokenCancelOffer",
 }
 
 # Types that effectively never succeed in this test environment:

--- a/workload/src/workload/params.py
+++ b/workload/src/workload/params.py
@@ -5,7 +5,7 @@ from workload.randoms import choice, randint, random
 
 # ── Fuzzing ──────────────────────────────────────────────────────────
 def should_send_faulty() -> bool:
-    return random() < 0.01
+    return random() < 0.5
 
 
 def fake_account() -> str:

--- a/workload/src/workload/transactions/account_delete.py
+++ b/workload/src/workload/transactions/account_delete.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import AccountDelete
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import UserAccount
 from workload.randoms import choice, randint
 from workload.submit import submit_tx
@@ -17,23 +19,23 @@ async def account_delete(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _account_delete_faulty(accounts, client)
+        return await _account_delete_faulty(accounts, protected_accounts, client)
     return await _account_delete_valid(accounts, protected_accounts, client)
 
 
-async def _account_delete_valid(
+def _account_delete_base(
     accounts: dict[str, UserAccount],
     protected_accounts: set[str],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[AccountDelete, Wallet] | None:
+    """Valid AccountDelete (delete an expendable account, funds to a peer) + wallet."""
     if len(accounts) < 2:
-        return
+        return None
 
     acct_list = list(accounts.values())
 
     expendable = [a for a in acct_list if a.address not in protected_accounts]
     if not expendable:
-        return
+        return None
 
     src = choice(expendable)
     dst = choice([a for a in acct_list if a.address != src.address])
@@ -42,11 +44,24 @@ async def _account_delete_valid(
         account=src.address,
         destination=dst.address,
     )
-    await submit_tx("AccountDelete", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _account_delete_valid(
+    accounts: dict[str, UserAccount],
+    protected_accounts: set[str],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _account_delete_base(accounts, protected_accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("AccountDelete", txn, client, wallet)
 
 
 async def _account_delete_faulty(
     accounts: dict[str, UserAccount],
+    protected_accounts: set[str],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -55,11 +70,20 @@ async def _account_delete_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "self_destination",
             "fake_destination",
             "delete_with_dest_tag",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _account_delete_base(accounts, protected_accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("AccountDelete", base, client, wallet)
+        return
 
     if mutation == "self_destination":
         txn = AccountDelete(

--- a/workload/src/workload/transactions/account_set.py
+++ b/workload/src/workload/transactions/account_set.py
@@ -2,13 +2,13 @@
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import AccountSet, AccountSetAsfFlag
+from xrpl.wallet import Wallet
 
-from workload import logging, params
+from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import UserAccount
 from workload.randoms import choice, random
-from workload.submit import submit_tx
-
-log = logging.getLogger(__name__)
+from workload.submit import submit_raw, submit_tx
 
 # Flags that affect trust lines and payments.
 INTERESTING_FLAGS: list[AccountSetAsfFlag] = [
@@ -31,16 +31,61 @@ async def account_set_random(accounts: dict[str, UserAccount], client: AsyncJson
     return await _account_set_valid(accounts, client)
 
 
-async def _account_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
-    account_id = choice(list(accounts))
-    account = accounts[account_id]
+def _account_set_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[AccountSet, Wallet] | None:
+    """Valid AccountSet (set or clear one flag) + wallet; shared by valid and fuzz."""
+    if not accounts:
+        return None
+    account = accounts[choice(list(accounts))]
     flag = choice(INTERESTING_FLAGS)
     if random() < 0.5:
         txn = AccountSet(account=account.address, set_flag=flag)
     else:
         txn = AccountSet(account=account.address, clear_flag=flag)
-    await submit_tx("AccountSet", txn, client, account.wallet)
+    return txn, account.wallet
+
+
+async def _account_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+    built = _account_set_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("AccountSet", txn, client, wallet)
 
 
 async def _account_set_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
-    pass  # TODO: fault injection
+    built = _account_set_base(accounts)
+    if built is None:
+        return
+    base, wallet = built
+
+    # All curated AccountSet malformations are tem (preflight, never enter the
+    # ledger): xrpl-py rejects bad TransferRate/TickSize and set==clear at
+    # construction, so they go through submit_raw.
+    mutation = choice(["bad_transfer_rate", "bad_tick_size", "set_clear_same_flag", "fuzz"])
+    if mutation == "fuzz":
+        await submit_fuzzed("AccountSet", base, client, wallet)
+        return
+
+    if mutation == "bad_transfer_rate":
+        # Valid range is 0 or 1e9..2e9 -> below 1e9 (but nonzero) is temBAD_TRANSFER_RATE.
+        def _mutate(d: dict) -> None:
+            d["TransferRate"] = 1
+
+    elif mutation == "bad_tick_size":
+        # Valid range is 0 or 3..15 -> 255 is temBAD_TICK_SIZE.
+        def _mutate(d: dict) -> None:
+            d["TickSize"] = 255
+
+    else:  # set_clear_same_flag
+        # SetFlag == ClearFlag -> temINVALID_FLAG.
+        flag = int(choice(INTERESTING_FLAGS))
+
+        def _mutate(d: dict) -> None:
+            d.pop("SetFlag", None)
+            d.pop("ClearFlag", None)
+            d["SetFlag"] = flag
+            d["ClearFlag"] = flag
+
+    await submit_raw("AccountSet", base, client, wallet, _mutate)

--- a/workload/src/workload/transactions/amm.py
+++ b/workload/src/workload/transactions/amm.py
@@ -385,17 +385,17 @@ async def amm_deposit(
     return await _amm_deposit_valid(accounts, amms, client)
 
 
-async def _amm_deposit_valid(
+def _amm_deposit_base(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[AMMDeposit, UserAccount] | None:
+    """Valid AMMDeposit + depositor; None when no two-asset AMM exists."""
     if not accounts or not amms:
-        return
+        return None
     amm = choice(amms)
     src = choice(list(accounts.values()))
     if len(amm.assets) < 2:
-        return
+        return None
     asset1, asset2 = amm.assets[0], amm.assets[1]
     mode = choice(
         [
@@ -433,7 +433,7 @@ async def _amm_deposit_valid(
 
     elif mode == "lp_token":
         if not amm.lp_token:
-            return
+            return None
         lp = amm.lp_token[0]
         lp_out = IOUAmount(
             currency=lp.currency,
@@ -450,7 +450,7 @@ async def _amm_deposit_valid(
 
     elif mode == "one_asset_lp_token":
         if not amm.lp_token:
-            return
+            return None
         lp = amm.lp_token[0]
         a = choice([asset1, asset2])
         amount = _amount_for(a, params.amm_deposit_amount())
@@ -493,6 +493,18 @@ async def _amm_deposit_valid(
             flags=AMMDepositFlag.TF_TWO_ASSET_IF_EMPTY,
         )
 
+    return txn, src
+
+
+async def _amm_deposit_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _amm_deposit_base(accounts, amms)
+    if built is None:
+        return
+    txn, src = built
     await submit_tx("AMMDeposit", txn, client, src.wallet)
 
 
@@ -506,6 +518,7 @@ async def _amm_deposit_faulty(
     src = choice(list(accounts.values()))
     mutation = choice(
         [
+            "fuzz",
             "non_existent_amm",
             "zero_deposit",
             "wrong_asset",
@@ -513,6 +526,14 @@ async def _amm_deposit_faulty(
             "negative_amount",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _amm_deposit_base(accounts, amms)
+        if built is None:
+            return
+        base, depositor = built
+        await submit_fuzzed("AMMDeposit", base, client, depositor.wallet)
+        return
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
@@ -614,17 +635,17 @@ async def amm_withdraw(
     return await _amm_withdraw_valid(accounts, amms, client)
 
 
-async def _amm_withdraw_valid(
+def _amm_withdraw_base(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[AMMWithdraw, UserAccount] | None:
+    """Valid AMMWithdraw + withdrawer; None when no two-asset AMM exists."""
     if not accounts or not amms:
-        return
+        return None
     amm = choice(amms)
     src = choice(list(accounts.values()))
     if len(amm.assets) < 2:
-        return
+        return None
     asset1, asset2 = amm.assets[0], amm.assets[1]
     mode = choice(
         [
@@ -651,7 +672,7 @@ async def _amm_withdraw_valid(
 
     elif mode == "lp_token":
         if not amm.lp_token:
-            return
+            return None
         lp = amm.lp_token[0]
         lp_in = IOUAmount(
             currency=lp.currency,
@@ -699,7 +720,7 @@ async def _amm_withdraw_valid(
 
     elif mode == "one_asset_lp_token":
         if not amm.lp_token:
-            return
+            return None
         lp = amm.lp_token[0]
         a = choice([asset1, asset2])
         amount = _amount_for(a, params.amm_withdraw_amount())
@@ -730,6 +751,18 @@ async def _amm_withdraw_valid(
             flags=AMMWithdrawFlag.TF_LIMIT_LP_TOKEN,
         )
 
+    return txn, src
+
+
+async def _amm_withdraw_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _amm_withdraw_base(accounts, amms)
+    if built is None:
+        return
+    txn, src = built
     await submit_tx("AMMWithdraw", txn, client, src.wallet)
 
 
@@ -743,6 +776,7 @@ async def _amm_withdraw_faulty(
     src = choice(list(accounts.values()))
     mutation = choice(
         [
+            "fuzz",
             "non_existent_amm",
             "zero_withdrawal",
             "overdraw",
@@ -750,6 +784,14 @@ async def _amm_withdraw_faulty(
             "negative_amount",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _amm_withdraw_base(accounts, amms)
+        if built is None:
+            return
+        base, withdrawer = built
+        await submit_fuzzed("AMMWithdraw", base, client, withdrawer.wallet)
+        return
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
@@ -853,8 +895,31 @@ async def amm_vote(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _amm_vote_faulty(accounts, amms, client)
+        return await _amm_vote_faulty(accounts, amms, trust_lines, client)
     return await _amm_vote_valid(accounts, amms, trust_lines, client)
+
+
+def _amm_vote_base(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+) -> tuple[AMMVote, UserAccount] | None:
+    """Valid AMMVote + voter holding the needed trust lines; None when none qualifies."""
+    if not accounts or not amms:
+        return None
+    amm = choice(amms)
+    # Filter to IOU legs: only those need a trust line, and MPTCurrency must not reach the matcher.
+    needed = [a for a in amm.assets if isinstance(a, IssuedCurrency)]
+    src = _find_account_with_trust_lines(accounts, trust_lines, needed)
+    if not src:
+        return None
+    txn = AMMVote(
+        account=src.address,
+        asset=amm.assets[0],
+        asset2=amm.assets[1],
+        trading_fee=params.amm_vote_fee(),
+    )
+    return txn, src
 
 
 async def _amm_vote_valid(
@@ -863,32 +928,31 @@ async def _amm_vote_valid(
     trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if not accounts or not amms:
+    built = _amm_vote_base(accounts, amms, trust_lines)
+    if built is None:
         return
-    amm = choice(amms)
-    # Filter to IOU legs: only those need a trust line, and MPTCurrency must not reach the matcher.
-    needed = [a for a in amm.assets if isinstance(a, IssuedCurrency)]
-    src = _find_account_with_trust_lines(accounts, trust_lines, needed)
-    if not src:
-        return
-    txn = AMMVote(
-        account=src.address,
-        asset=amm.assets[0],
-        asset2=amm.assets[1],
-        trading_fee=params.amm_vote_fee(),
-    )
+    txn, src = built
     await submit_tx("AMMVote", txn, client, src.wallet)
 
 
 async def _amm_vote_faulty(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
+    trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice(["non_existent_amm", "non_lp_holder_vote", "swapped_assets"])
+    mutation = choice(["fuzz", "non_existent_amm", "non_lp_holder_vote", "swapped_assets"])
+
+    if mutation == "fuzz":
+        built = _amm_vote_base(accounts, amms, trust_lines)
+        if built is None:
+            return
+        base, voter = built
+        await submit_fuzzed("AMMVote", base, client, voter.wallet)
+        return
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
@@ -941,16 +1005,16 @@ async def amm_bid(
     return await _amm_bid_valid(accounts, amms, client)
 
 
-async def _amm_bid_valid(
+def _amm_bid_base(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[AMMBid, UserAccount] | None:
+    """Valid AMMBid + bidder; None when no two-asset AMM with LP tokens exists."""
     if not accounts or not amms:
-        return
+        return None
     amm = choice(amms)
     if not amm.lp_token or len(amm.assets) < 2:
-        return
+        return None
     src = choice(list(accounts.values()))
     lp = amm.lp_token[0]
     mode = choice(["basic_bid", "bid_with_auth_accounts"])
@@ -979,6 +1043,18 @@ async def _amm_bid_valid(
             auth_accounts=auth_accounts,
         )
 
+    return txn, src
+
+
+async def _amm_bid_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _amm_bid_base(accounts, amms)
+    if built is None:
+        return
+    txn, src = built
     await submit_tx("AMMBid", txn, client, src.wallet)
 
 
@@ -992,6 +1068,7 @@ async def _amm_bid_faulty(
     src = choice(list(accounts.values()))
     mutation = choice(
         [
+            "fuzz",
             "non_existent_amm",
             "zero_bid",
             "bid_min_exceeds_max",
@@ -999,6 +1076,14 @@ async def _amm_bid_faulty(
             "non_lp_holder_bid",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _amm_bid_base(accounts, amms)
+        if built is None:
+            return
+        base, bidder = built
+        await submit_fuzzed("AMMBid", base, client, bidder.wallet)
+        return
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()
@@ -1091,20 +1176,34 @@ async def amm_delete(
     return await _amm_delete_valid(accounts, amms, client)
 
 
-async def _amm_delete_valid(
+def _amm_delete_base(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[AMMDelete, UserAccount] | None:
+    """Valid AMMDelete + submitter; None when no two-asset AMM exists."""
     if not accounts or not amms:
-        return
+        return None
     amm = choice(amms)
+    if len(amm.assets) < 2:
+        return None
     src = choice(list(accounts.values()))
     txn = AMMDelete(
         account=src.address,
         asset=amm.assets[0],
         asset2=amm.assets[1],
     )
+    return txn, src
+
+
+async def _amm_delete_valid(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _amm_delete_base(accounts, amms)
+    if built is None:
+        return
+    txn, src = built
     await submit_tx("AMMDelete", txn, client, src.wallet)
 
 
@@ -1116,7 +1215,15 @@ async def _amm_delete_faulty(
     if not accounts:
         return
     src = choice(list(accounts.values()))
-    mutation = choice(["non_existent_amm", "non_empty_amm", "wrong_asset_pair"])
+    mutation = choice(["fuzz", "non_existent_amm", "non_empty_amm", "wrong_asset_pair"])
+
+    if mutation == "fuzz":
+        built = _amm_delete_base(accounts, amms)
+        if built is None:
+            return
+        base, submitter = built
+        await submit_fuzzed("AMMDelete", base, client, submitter.wallet)
+        return
 
     if mutation == "non_existent_amm":
         fake = _fake_iou()

--- a/workload/src/workload/transactions/batch.py
+++ b/workload/src/workload/transactions/batch.py
@@ -16,15 +16,15 @@ from xrpl.models.transactions import (
 )
 from xrpl.models.transactions.deposit_preauth import Credential as XRPLCredential
 from xrpl.models.transactions.transaction import Memo, Transaction
+from xrpl.wallet import Wallet
 
-from workload import logging, params
+from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import UserAccount
 from workload.randoms import choice, sample
 from workload.submit import submit_tx
 
-log = logging.getLogger(__name__)
-
-# TODO: ASF_AUTHORIZED_NFTOKEN_MINTER excluded — requires nftoken_minter field (AXRT-118)
+# ASF_AUTHORIZED_NFTOKEN_MINTER excluded — requires the nftoken_minter field.
 _BATCH_SAFE_FLAGS: list[AccountSetAsfFlag] = [
     f for f in AccountSetAsfFlag if f != AccountSetAsfFlag.ASF_AUTHORIZED_NFTOKEN_MINTER
 ]
@@ -110,21 +110,31 @@ async def batch_random(accounts: dict[str, UserAccount], client: AsyncJsonRpcCli
     return await _batch_random_valid(accounts, client)
 
 
-async def _batch_random_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+async def _batch_base(
+    accounts: dict[str, UserAccount], client: AsyncJsonRpcClient
+) -> tuple[Batch, Wallet] | None:
+    """Valid single-account Batch + wallet; shared by valid and fuzz."""
+    if len(accounts) < 2:
+        return None
     src_address, dst = sample(list(accounts), 2)
     sequence = await get_next_valid_seq_number(src_address, client)
     src = accounts[src_address]
-    num_txns = params.batch_size()
-
-    inner_txns = [_build_inner(src, dst, sequence + idx + 1) for idx in range(num_txns)]
-
+    inner_txns = [_build_inner(src, dst, sequence + idx + 1) for idx in range(params.batch_size())]
     batch_txn = Batch(
         account=src.address,
         flags=choice(list(BatchFlag)),
         raw_transactions=inner_txns,
         sequence=sequence,
     )
-    await submit_tx("Batch", batch_txn, client, src.wallet)
+    return batch_txn, src.wallet
+
+
+async def _batch_random_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+    built = await _batch_base(accounts, client)
+    if built is None:
+        return
+    batch_txn, wallet = built
+    await submit_tx("Batch", batch_txn, client, wallet)
 
 
 async def _batch_random_faulty(
@@ -132,6 +142,17 @@ async def _batch_random_faulty(
 ) -> None:
     if len(accounts) < 2:
         return
+
+    # Single-account batch: submit_raw single-signs correctly (only multi-account
+    # batches need BatchSigners), so fuzzing the outer dict reaches Batch preflight.
+    if choice(["overdraw_all_or_nothing", "fuzz"]) == "fuzz":
+        built = await _batch_base(accounts, client)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("Batch", base, client, wallet)
+        return
+
     src_address, dst = sample(list(accounts), 2)
     sequence = await get_next_valid_seq_number(src_address, client)
     src = accounts[src_address]

--- a/workload/src/workload/transactions/checks.py
+++ b/workload/src/workload/transactions/checks.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import CheckCancel, CheckCash, CheckCreate
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import Check, UserAccount
 from workload.randoms import choice, randint
 from workload.submit import submit_tx
@@ -23,13 +25,12 @@ async def check_create(
     return await _check_create_valid(accounts, checks, client)
 
 
-async def _check_create_valid(
+def _check_create_base(
     accounts: dict[str, UserAccount],
-    checks: list[Check],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[CheckCreate, Wallet] | None:
+    """Valid CheckCreate + wallet; shared by valid and fuzz."""
     if not accounts:
-        return
+        return None
 
     acct_list = list(accounts.values())
     src = choice(acct_list)
@@ -42,7 +43,19 @@ async def _check_create_valid(
         destination=dst.address,
         send_max=send_max,
     )
-    result = await submit_tx("CheckCreate", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _check_create_valid(
+    accounts: dict[str, UserAccount],
+    checks: list[Check],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _check_create_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    result = await submit_tx("CheckCreate", txn, client, wallet)
 
     # Track only when the submit will likely apply (state updater later swaps
     # the hash placeholder for the real check_id), else the placeholder leaks.
@@ -50,13 +63,14 @@ async def _check_create_valid(
     if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ"):
         tx_json = result.get("tx_json", result)
         check_id = tx_json.get("hash", "")
-        if check_id:
+        # The base always builds an XRP-drops str send_max; narrow for Check.send_max.
+        if check_id and isinstance(txn.send_max, str):
             checks.append(
                 Check(
                     check_id=check_id,
-                    creator=src.address,
-                    destination=dst.address,
-                    send_max=send_max,
+                    creator=txn.account,
+                    destination=txn.destination,
+                    send_max=txn.send_max,
                 )
             )
 
@@ -71,12 +85,20 @@ async def _check_create_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "zero_send_max",
             "self_destination",
             "non_existent_destination",
             "past_expiration",
         ]
     )
+    if mutation == "fuzz":
+        built = _check_create_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("CheckCreate", base, client, wallet)
+        return
 
     if mutation == "zero_send_max":
         txn = CheckCreate(
@@ -117,28 +139,27 @@ async def check_cash(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _check_cash_faulty(accounts, client)
+        return await _check_cash_faulty(accounts, checks, client)
     return await _check_cash_valid(accounts, checks, client)
 
 
-async def _check_cash_valid(
+def _check_cash_base(
     accounts: dict[str, UserAccount],
     checks: list[Check],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[CheckCash, Wallet] | None:
+    """Valid CheckCash of a tracked check + wallet; shared by valid and fuzz."""
     if not checks:
-        return
+        return None
 
     check = choice(checks)
     # Only the destination can cash a check.
     dst = accounts.get(check.destination)
     if not dst:
-        return
+        return None
 
-    use_exact = choice([True, False])
     cash_amount = params.check_cash_amount(check.send_max)
 
-    if use_exact:
+    if choice([True, False]):
         txn = CheckCash(
             account=dst.address,
             check_id=check.check_id,
@@ -150,12 +171,24 @@ async def _check_cash_valid(
             check_id=check.check_id,
             deliver_min=cash_amount,
         )
+    return txn, dst.wallet
 
-    await submit_tx("CheckCash", txn, client, dst.wallet)
+
+async def _check_cash_valid(
+    accounts: dict[str, UserAccount],
+    checks: list[Check],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _check_cash_base(accounts, checks)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("CheckCash", txn, client, wallet)
 
 
 async def _check_cash_faulty(
     accounts: dict[str, UserAccount],
+    checks: list[Check],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -164,11 +197,19 @@ async def _check_cash_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "fake_check_id",
             "zero_amount",
             "non_destination_cash",
         ]
     )
+    if mutation == "fuzz":
+        built = _check_cash_base(accounts, checks)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("CheckCash", base, client, wallet)
+        return
 
     if mutation == "fake_check_id":
         txn = CheckCash(
@@ -201,8 +242,30 @@ async def check_cancel(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _check_cancel_faulty(accounts, client)
+        return await _check_cancel_faulty(accounts, checks, client)
     return await _check_cancel_valid(accounts, checks, client)
+
+
+def _check_cancel_base(
+    accounts: dict[str, UserAccount],
+    checks: list[Check],
+) -> tuple[CheckCancel, Wallet] | None:
+    """Valid CheckCancel of a tracked check + wallet; shared by valid and fuzz."""
+    if not checks:
+        return None
+
+    check = choice(checks)
+    # Creator or destination can cancel.
+    canceller_addr = choice([check.creator, check.destination])
+    canceller = accounts.get(canceller_addr)
+    if not canceller:
+        return None
+
+    txn = CheckCancel(
+        account=canceller.address,
+        check_id=check.check_id,
+    )
+    return txn, canceller.wallet
 
 
 async def _check_cancel_valid(
@@ -210,25 +273,16 @@ async def _check_cancel_valid(
     checks: list[Check],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if not checks:
+    built = _check_cancel_base(accounts, checks)
+    if built is None:
         return
-
-    check = choice(checks)
-    # Creator or destination can cancel.
-    canceller_addr = choice([check.creator, check.destination])
-    canceller = accounts.get(canceller_addr)
-    if not canceller:
-        return
-
-    txn = CheckCancel(
-        account=canceller.address,
-        check_id=check.check_id,
-    )
-    await submit_tx("CheckCancel", txn, client, canceller.wallet)
+    txn, wallet = built
+    await submit_tx("CheckCancel", txn, client, wallet)
 
 
 async def _check_cancel_faulty(
     accounts: dict[str, UserAccount],
+    checks: list[Check],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -237,10 +291,18 @@ async def _check_cancel_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "fake_check_id",
             "cancel_others_check",
         ]
     )
+    if mutation == "fuzz":
+        built = _check_cancel_base(accounts, checks)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("CheckCancel", base, client, wallet)
+        return
 
     if mutation == "fake_check_id":
         txn = CheckCancel(

--- a/workload/src/workload/transactions/clawback.py
+++ b/workload/src/workload/transactions/clawback.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.amounts import IssuedCurrencyAmount, MPTAmount
 from xrpl.models.transactions import Clawback
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import MPTokenIssuance, TrustLine, UserAccount
 from workload.randoms import choice
 from workload.submit import submit_tx
@@ -23,19 +25,19 @@ async def clawback(
     return await _clawback_valid(accounts, trust_lines, mpt_issuances, client)
 
 
-async def _clawback_valid(
+def _clawback_base(
     accounts: dict[str, UserAccount],
     trust_lines: list[TrustLine],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[Clawback, Wallet] | None:
+    """Valid Clawback (issuer claws back an IOU or MPT from a holder) + wallet."""
     if not accounts:
-        return
+        return None
 
     can_iou = bool(trust_lines)
     can_mpt = bool(mpt_issuances)
     if not can_iou and not can_mpt:
-        return
+        return None
 
     flavours = []
     if can_iou:
@@ -45,21 +47,19 @@ async def _clawback_valid(
     flavour = choice(flavours)
 
     if flavour == "iou":
-        await _clawback_iou_valid(accounts, trust_lines, client)
-    else:
-        await _clawback_mpt_valid(accounts, mpt_issuances, client)
+        return _clawback_iou_base(accounts, trust_lines)
+    return _clawback_mpt_base(accounts, mpt_issuances)
 
 
-async def _clawback_iou_valid(
+def _clawback_iou_base(
     accounts: dict[str, UserAccount],
     trust_lines: list[TrustLine],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[Clawback, Wallet] | None:
     tl = choice(trust_lines)
     # account_b is the gateway/issuer, account_a is the holder
     gateway = accounts.get(tl.account_b)
     if not gateway:
-        return
+        return None
 
     txn = Clawback(
         account=gateway.address,
@@ -69,22 +69,21 @@ async def _clawback_iou_valid(
             value=params.clawback_iou_amount(),
         ),
     )
-    await submit_tx("Clawback", txn, client, gateway.wallet)
+    return txn, gateway.wallet
 
 
-async def _clawback_mpt_valid(
+def _clawback_mpt_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[Clawback, Wallet] | None:
     mpt = choice(mpt_issuances)
     issuer = accounts.get(mpt.issuer)
     if not issuer:
-        return
+        return None
 
     holders = [a for a in accounts.values() if a.address != mpt.issuer]
     if not holders:
-        return
+        return None
     holder = choice(holders)
 
     txn = Clawback(
@@ -95,7 +94,20 @@ async def _clawback_mpt_valid(
         ),
         holder=holder.address,
     )
-    await submit_tx("Clawback", txn, client, issuer.wallet)
+    return txn, issuer.wallet
+
+
+async def _clawback_valid(
+    accounts: dict[str, UserAccount],
+    trust_lines: list[TrustLine],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _clawback_base(accounts, trust_lines, mpt_issuances)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("Clawback", txn, client, wallet)
 
 
 async def _clawback_faulty(
@@ -110,6 +122,7 @@ async def _clawback_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "non_issuer_iou",
             "zero_iou_amount",
             "fake_holder_mpt",
@@ -117,6 +130,14 @@ async def _clawback_faulty(
             "fake_mpt_issuance",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _clawback_base(accounts, trust_lines, mpt_issuances)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("Clawback", base, client, wallet)
+        return
 
     if mutation == "non_issuer_iou":
         dst = choice(list(accounts.values()))

--- a/workload/src/workload/transactions/credentials.py
+++ b/workload/src/workload/transactions/credentials.py
@@ -8,8 +8,10 @@ from xrpl.models.transactions import (
     CredentialCreate,
     CredentialDelete,
 )
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import Credential, UserAccount
 from workload.randoms import choice, sample
 from workload.submit import submit_tx
@@ -25,28 +27,48 @@ async def credential_create(
     return await _credential_create_valid(accounts, credentials, client)
 
 
-async def _credential_create_valid(
-    accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
-) -> None:
+def _credential_create_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[CredentialCreate, Wallet] | None:
+    """Valid CredentialCreate (issuer credentials a subject) + wallet; shared by valid and fuzz."""
+    if len(accounts) < 2:
+        return None
     issuer_id, subject_id = sample(list(accounts), 2)
     issuer = accounts[issuer_id]
-    cred_type = params.credential_type()
     txn = CredentialCreate(
         account=issuer.address,
         subject=subject_id,
-        credential_type=cred_type,
+        credential_type=params.credential_type(),
         expiration=int(time.time()) + params.credential_expiration_offset(),
         uri=params.credential_uri(),
     )
-    await submit_tx("CredentialCreate", txn, client, issuer.wallet)
+    return txn, issuer.wallet
+
+
+async def _credential_create_valid(
+    accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
+) -> None:
+    built = _credential_create_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("CredentialCreate", txn, client, wallet)
 
 
 async def _credential_create_faulty(
     accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
 ) -> None:
+    if choice(["fuzz", "duplicate"]) == "fuzz":
+        built = _credential_create_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("CredentialCreate", base, client, wallet)
+        return
+
+    # duplicate: re-create an existing credential -> tecDUPLICATE.
     if not credentials:
         return
-    # Re-create an existing credential → tecDUPLICATE from rippled
     cred = choice(credentials)
     if cred.issuer not in accounts:
         return
@@ -70,13 +92,78 @@ async def credential_accept(
     return await _credential_accept_valid(accounts, credentials, client)
 
 
+def _credential_accept_base(
+    accounts: dict[str, UserAccount], credentials: list[Credential]
+) -> tuple[CredentialAccept, Wallet] | None:
+    """Valid CredentialAccept (subject accepts an issued credential) + wallet."""
+    subjects = [c for c in credentials if c.subject in accounts]
+    if not subjects:
+        return None
+    cred = choice(subjects)
+    subject = accounts[cred.subject]
+    txn = CredentialAccept(
+        account=subject.address,
+        issuer=cred.issuer,
+        credential_type=cred.credential_type,
+    )
+    return txn, subject.wallet
+
+
 async def _credential_accept_valid(
     accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
 ) -> None:
-    unaccepted = [c for c in credentials if c.subject in accounts]
-    if not unaccepted:
+    built = _credential_accept_base(accounts, credentials)
+    if built is None:
         return
-    cred = choice(unaccepted)
+    txn, wallet = built
+    await submit_tx("CredentialAccept", txn, client, wallet)
+
+
+async def _credential_accept_faulty(
+    accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
+) -> None:
+    if not accounts:
+        return
+
+    mutation = choice(["fuzz", "no_entry", "fake_issuer", "already_accepted"])
+    if mutation == "fuzz":
+        built = _credential_accept_base(accounts, credentials)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("CredentialAccept", base, client, wallet)
+        return
+
+    if mutation == "no_entry":
+        # Accept a credential type that was never issued -> tecNO_ENTRY.
+        if len(accounts) < 2:
+            return
+        subject_id, issuer_id = sample(list(accounts), 2)
+        subject = accounts[subject_id]
+        txn = CredentialAccept(
+            account=subject.address,
+            issuer=issuer_id,
+            credential_type=params.credential_type(),
+        )
+        await submit_tx("CredentialAccept", txn, client, subject.wallet)
+        return
+
+    if mutation == "fake_issuer":
+        # Issuer account does not exist -> tecNO_ISSUER.
+        subject = choice(list(accounts.values()))
+        txn = CredentialAccept(
+            account=subject.address,
+            issuer=params.fake_account(),
+            credential_type=params.credential_type(),
+        )
+        await submit_tx("CredentialAccept", txn, client, subject.wallet)
+        return
+
+    # already_accepted: re-accept an accepted credential -> tecDUPLICATE.
+    accepted = [c for c in credentials if c.accepted and c.subject in accounts]
+    if not accepted:
+        return
+    cred = choice(accepted)
     subject = accounts[cred.subject]
     txn = CredentialAccept(
         account=subject.address,
@@ -84,12 +171,6 @@ async def _credential_accept_valid(
         credential_type=cred.credential_type,
     )
     await submit_tx("CredentialAccept", txn, client, subject.wallet)
-
-
-async def _credential_accept_faulty(
-    accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
-) -> None:
-    pass  # TODO: fault injection
 
 
 # ── Delete ───────────────────────────────────────────────────────────
@@ -103,27 +184,79 @@ async def credential_delete(
     return await _credential_delete_valid(accounts, credentials, client)
 
 
-async def _credential_delete_valid(
-    accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
-) -> None:
+def _credential_delete_base(
+    accounts: dict[str, UserAccount], credentials: list[Credential]
+) -> tuple[CredentialDelete, Wallet] | None:
+    """Valid CredentialDelete (issuer or subject deletes the credential) + wallet."""
     if not credentials:
-        return
+        return None
     cred = choice(credentials)
     if cred.issuer in accounts:
         account = accounts[cred.issuer]
     elif cred.subject in accounts:
         account = accounts[cred.subject]
     else:
-        return
+        return None
     txn = CredentialDelete(
         account=account.address,
         subject=cred.subject,
         credential_type=cred.credential_type,
     )
-    await submit_tx("CredentialDelete", txn, client, account.wallet)
+    return txn, account.wallet
+
+
+async def _credential_delete_valid(
+    accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
+) -> None:
+    built = _credential_delete_base(accounts, credentials)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("CredentialDelete", txn, client, wallet)
 
 
 async def _credential_delete_faulty(
     accounts: dict[str, UserAccount], credentials: list[Credential], client: AsyncJsonRpcClient
 ) -> None:
-    pass  # TODO: fault injection
+    if not accounts:
+        return
+
+    mutation = choice(["fuzz", "no_entry", "third_party"])
+    if mutation == "fuzz":
+        built = _credential_delete_base(accounts, credentials)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("CredentialDelete", base, client, wallet)
+        return
+
+    if mutation == "no_entry":
+        # Delete a credential type that does not exist -> tecNO_ENTRY.
+        if len(accounts) < 2:
+            return
+        account_id, subject_id = sample(list(accounts), 2)
+        account = accounts[account_id]
+        txn = CredentialDelete(
+            account=account.address,
+            subject=subject_id,
+            credential_type=params.credential_type(),
+        )
+        await submit_tx("CredentialDelete", txn, client, account.wallet)
+        return
+
+    # third_party: an account that is neither issuer nor subject deletes a
+    # non-expired credential -> tecNO_PERMISSION.
+    if not credentials:
+        return
+    cred = choice(credentials)
+    outsiders = [a for a in accounts if a != cred.issuer and a != cred.subject]
+    if not outsiders:
+        return
+    src = accounts[choice(outsiders)]
+    txn = CredentialDelete(
+        account=src.address,
+        subject=cred.subject,
+        issuer=cred.issuer,
+        credential_type=cred.credential_type,
+    )
+    await submit_tx("CredentialDelete", txn, client, src.wallet)

--- a/workload/src/workload/transactions/delegation.py
+++ b/workload/src/workload/transactions/delegation.py
@@ -10,14 +10,13 @@ from xrpl.models.transactions.delegate_set import (
 from xrpl.models.transactions.types import TransactionType
 from xrpl.wallet import Wallet
 
-from workload import logging, params
+from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import UserAccount
 from workload.randoms import choice, randint, sample
 from workload.submit import submit_tx
 
 DELEGABLE_TX_TYPES = [t for t in TransactionType if t not in NON_DELEGABLE_TRANSACTIONS]
-
-log = logging.getLogger(__name__)
 
 
 async def delegate_set(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
@@ -26,7 +25,12 @@ async def delegate_set(accounts: dict[str, UserAccount], client: AsyncJsonRpcCli
     return await _delegate_set_valid(accounts, client)
 
 
-async def _delegate_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+def _delegate_set_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[DelegateSet, Wallet] | None:
+    """Valid DelegateSet (grant a delegate a random permission set) + wallet."""
+    if len(accounts) < 2:
+        return None
     src_id, delegate_id = sample(list(accounts), 2)
     src = accounts[src_id]
     perm_type = choice(["granular", "transaction_type", "mixed"])
@@ -44,7 +48,15 @@ async def _delegate_set_valid(accounts: dict[str, UserAccount], client: AsyncJso
         authorize=delegate_id,
         permissions=permissions,
     )
-    await submit_tx("DelegateSet", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _delegate_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+    built = _delegate_set_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("DelegateSet", txn, client, wallet)
 
 
 async def _delegate_set_faulty(
@@ -54,11 +66,20 @@ async def _delegate_set_faulty(
         return
     mutation = choice(
         [
+            "fuzz",
             "non_existent_authorize",
             "empty_permissions",
             "non_owner_submission",
         ]
     )
+    if mutation == "fuzz":
+        built = _delegate_set_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("DelegateSet", base, client, wallet)
+        return
+
     if mutation == "non_existent_authorize":
         src = choice(list(accounts.values()))
         all_perms = list(GranularPermission)

--- a/workload/src/workload/transactions/did.py
+++ b/workload/src/workload/transactions/did.py
@@ -2,8 +2,10 @@
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import DIDDelete, DIDSet
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import DID, UserAccount
 from workload.randoms import choice, random, sample
 from workload.submit import submit_tx
@@ -28,7 +30,10 @@ async def did_set(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) 
     return await _did_set_valid(accounts, client)
 
 
-async def _did_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+def _did_set_base(accounts: dict[str, UserAccount]) -> tuple[DIDSet, Wallet] | None:
+    """Valid DIDSet (partial clear or field combo) + wallet; shared by valid and fuzz."""
+    if not accounts:
+        return None
     src = choice(list(accounts.values()))
 
     if random() < 0.10:
@@ -42,8 +47,7 @@ async def _did_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcC
             data=all_fields["data"],
             did_document=all_fields["did_document"],
         )
-        await submit_tx("DIDSet", txn, client, src.wallet)
-        return
+        return txn, src.wallet
 
     combo = choice(VALID_FIELD_COMBOS)
     fields = {f: params.did_hex_field() for f in combo}
@@ -53,7 +57,15 @@ async def _did_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcC
         data=fields.get("data"),
         did_document=fields.get("did_document"),
     )
-    await submit_tx("DIDSet", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _did_set_valid(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
+    built = _did_set_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("DIDSet", txn, client, wallet)
 
 
 async def _did_set_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
@@ -64,8 +76,16 @@ async def _did_set_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpc
             "non_owner_submission",
             "invalid_flags",
             "single_empty_field",
+            "fuzz",
         ]
     )
+    if mutation == "fuzz":
+        built = _did_set_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("DIDSet", base, client, wallet)
+        return
     if mutation == "non_owner_submission":
         accounts_list = list(accounts.values())
         if len(accounts_list) < 2:
@@ -101,17 +121,28 @@ async def did_delete(
     return await _did_delete_valid(accounts, dids, client)
 
 
+def _did_delete_base(
+    accounts: dict[str, UserAccount], dids: list[DID]
+) -> tuple[DIDDelete, Wallet] | None:
+    """Valid DIDDelete (owner deletes own DID) + wallet; shared by valid and fuzz."""
+    if not dids:
+        return None
+    target = choice(dids)
+    if target.account not in accounts:
+        return None
+    owner = accounts[target.account]
+    txn = DIDDelete(account=owner.address)
+    return txn, owner.wallet
+
+
 async def _did_delete_valid(
     accounts: dict[str, UserAccount], dids: list[DID], client: AsyncJsonRpcClient
 ) -> None:
-    if not dids:
+    built = _did_delete_base(accounts, dids)
+    if built is None:
         return
-    target = choice(dids)
-    if target.account not in accounts:
-        return
-    owner = accounts[target.account]
-    txn = DIDDelete(account=owner.address)
-    await submit_tx("DIDDelete", txn, client, owner.wallet)
+    txn, wallet = built
+    await submit_tx("DIDDelete", txn, client, wallet)
 
 
 async def _did_delete_faulty(
@@ -124,8 +155,16 @@ async def _did_delete_faulty(
             "delete_no_did",
             "non_owner_submission",
             "invalid_flags",
+            "fuzz",
         ]
     )
+    if mutation == "fuzz":
+        built = _did_delete_base(accounts, dids)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("DIDDelete", base, client, wallet)
+        return
     accounts_list = list(accounts.values())
     if mutation == "delete_no_did":
         did_owners = {d.account for d in dids}

--- a/workload/src/workload/transactions/escrow.py
+++ b/workload/src/workload/transactions/escrow.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import EscrowCancel, EscrowCreate, EscrowFinish
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import Escrow, UserAccount
 from workload.randoms import choice, randint
 from workload.submit import submit_tx
@@ -23,13 +25,16 @@ async def escrow_create(
     return await _escrow_create_valid(accounts, escrows, client)
 
 
-async def _escrow_create_valid(
+def _escrow_create_base(
     accounts: dict[str, UserAccount],
-    escrows: list[Escrow],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[EscrowCreate, Wallet, str | None] | None:
+    """Valid EscrowCreate + wallet + fulfillment; shared by valid and fuzz.
+
+    Fulfillment is one-way-derived from the condition and unrecoverable from the
+    txn, so it rides alongside for the valid path's escrow tracking.
+    """
     if not accounts:
-        return
+        return None
 
     acct_list = list(accounts.values())
     src = choice(acct_list)
@@ -62,7 +67,19 @@ async def _escrow_create_valid(
         cancel_after=cancel_after,
         condition=condition,
     )
-    result = await submit_tx("EscrowCreate", txn, client, src.wallet)
+    return txn, src.wallet, fulfillment
+
+
+async def _escrow_create_valid(
+    accounts: dict[str, UserAccount],
+    escrows: list[Escrow],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _escrow_create_base(accounts)
+    if built is None:
+        return
+    txn, wallet, fulfillment = built
+    result = await submit_tx("EscrowCreate", txn, client, wallet)
 
     # Track only when the submit will likely apply, else the entry leaks and
     # Finish/Cancel pick dead escrows.
@@ -73,13 +90,13 @@ async def _escrow_create_valid(
         if seq:
             escrows.append(
                 Escrow(
-                    owner=src.address,
-                    destination=dst.address,
+                    owner=txn.account,
+                    destination=txn.destination,
                     sequence=seq,
-                    condition=condition,
+                    condition=txn.condition,
                     fulfillment=fulfillment,
-                    finish_after=finish_after,
-                    cancel_after=cancel_after,
+                    finish_after=txn.finish_after,
+                    cancel_after=txn.cancel_after,
                 )
             )
 
@@ -94,12 +111,21 @@ async def _escrow_create_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "past_cancel_after",
             "non_existent_destination",
             "bad_condition_hex",
             "no_time_no_condition",
         ]
     )
+    if mutation == "fuzz":
+        built = _escrow_create_base(accounts)
+        if built is None:
+            return
+        base, wallet, _ = built
+        await submit_fuzzed("EscrowCreate", base, client, wallet)
+        return
+
     if mutation == "past_cancel_after":
         past = params._ripple_now() - randint(100, 10_000)
         txn = EscrowCreate(
@@ -144,17 +170,17 @@ async def escrow_finish(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _escrow_finish_faulty(accounts, client)
+        return await _escrow_finish_faulty(accounts, escrows, client)
     return await _escrow_finish_valid(accounts, escrows, client)
 
 
-async def _escrow_finish_valid(
+def _escrow_finish_base(
     accounts: dict[str, UserAccount],
     escrows: list[Escrow],
-    client: AsyncJsonRpcClient,
-) -> None:
-    if not escrows:
-        return
+) -> tuple[EscrowFinish, Wallet] | None:
+    """Valid EscrowFinish of a tracked escrow + wallet; shared by valid and fuzz."""
+    if not escrows or not accounts:
+        return None
 
     escrow = choice(escrows)
     # Anyone can finish an escrow.
@@ -167,11 +193,24 @@ async def _escrow_finish_valid(
         condition=escrow.condition,
         fulfillment=escrow.fulfillment,
     )
-    await submit_tx("EscrowFinish", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _escrow_finish_valid(
+    accounts: dict[str, UserAccount],
+    escrows: list[Escrow],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _escrow_finish_base(accounts, escrows)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("EscrowFinish", txn, client, wallet)
 
 
 async def _escrow_finish_faulty(
     accounts: dict[str, UserAccount],
+    escrows: list[Escrow],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -180,11 +219,20 @@ async def _escrow_finish_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "non_existent_sequence",
             "wrong_fulfillment",
             "wrong_owner",
         ]
     )
+    if mutation == "fuzz":
+        built = _escrow_finish_base(accounts, escrows)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("EscrowFinish", base, client, wallet)
+        return
+
     if mutation == "non_existent_sequence":
         txn = EscrowFinish(
             account=src.address,
@@ -221,21 +269,21 @@ async def escrow_cancel(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _escrow_cancel_faulty(accounts, client)
+        return await _escrow_cancel_faulty(accounts, escrows, client)
     return await _escrow_cancel_valid(accounts, escrows, client)
 
 
-async def _escrow_cancel_valid(
+def _escrow_cancel_base(
     accounts: dict[str, UserAccount],
     escrows: list[Escrow],
-    client: AsyncJsonRpcClient,
-) -> None:
-    if not escrows:
-        return
+) -> tuple[EscrowCancel, Wallet] | None:
+    """Valid EscrowCancel of a cancellable escrow + wallet; shared by valid and fuzz."""
+    if not escrows or not accounts:
+        return None
 
     cancellable = [e for e in escrows if e.cancel_after is not None]
     if not cancellable:
-        return
+        return None
 
     escrow = choice(cancellable)
     # Anyone can cancel an expired escrow.
@@ -246,11 +294,24 @@ async def _escrow_cancel_valid(
         owner=escrow.owner,
         offer_sequence=escrow.sequence,
     )
-    await submit_tx("EscrowCancel", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _escrow_cancel_valid(
+    accounts: dict[str, UserAccount],
+    escrows: list[Escrow],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _escrow_cancel_base(accounts, escrows)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("EscrowCancel", txn, client, wallet)
 
 
 async def _escrow_cancel_faulty(
     accounts: dict[str, UserAccount],
+    escrows: list[Escrow],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -259,11 +320,20 @@ async def _escrow_cancel_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "non_existent_sequence",
             "wrong_owner",
             "cancel_non_cancellable",
         ]
     )
+    if mutation == "fuzz":
+        built = _escrow_cancel_base(accounts, escrows)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("EscrowCancel", base, client, wallet)
+        return
+
     if mutation == "non_existent_sequence":
         txn = EscrowCancel(
             account=src.address,

--- a/workload/src/workload/transactions/lending.py
+++ b/workload/src/workload/transactions/lending.py
@@ -15,9 +15,11 @@ from xrpl.models.transactions import (
 )
 from xrpl.models.transactions.loan_manage import LoanManageFlag
 from xrpl.transaction.counterparty_signer import sign_loan_set_by_counterparty
+from xrpl.wallet import Wallet
 
 from workload import params
 from workload.assertions import tx_submitted
+from workload.fuzz import submit_fuzzed
 from workload.models import Loan, LoanBroker, UserAccount, Vault
 from workload.randoms import choice, randint
 from workload.submit import submit_tx
@@ -36,17 +38,15 @@ async def loan_broker_set(
     return await _loan_broker_set_valid(accounts, vaults, loan_brokers, client)
 
 
-async def _loan_broker_set_valid(
+def _loan_broker_set_base(
     accounts: dict[str, UserAccount],
     vaults: list[Vault],
-    loan_brokers: list[LoanBroker],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[LoanBrokerSet, Wallet] | None:
     if not vaults:
-        return
+        return None
     vault = choice(vaults)
     if vault.owner not in accounts:
-        return
+        return None
     owner = accounts[vault.owner]
     txn = LoanBrokerSet(
         account=owner.address,
@@ -58,7 +58,20 @@ async def _loan_broker_set_valid(
         debt_maximum=params.loan_broker_debt_maximum(),
         data=params.loan_broker_data(),
     )
-    await submit_tx("LoanBrokerSet", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _loan_broker_set_valid(
+    accounts: dict[str, UserAccount],
+    vaults: list[Vault],
+    loan_brokers: list[LoanBroker],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _loan_broker_set_base(accounts, vaults)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanBrokerSet", txn, client, wallet)
 
 
 async def _loan_broker_set_faulty(
@@ -70,7 +83,15 @@ async def _loan_broker_set_faulty(
     if not accounts:
         return
     acc = choice(list(accounts.values()))
-    mutation = choice(["nonexistent_vault", "cover_rate_asymmetry", "non_vault_owner"])
+    mutation = choice(["fuzz", "nonexistent_vault", "cover_rate_asymmetry", "non_vault_owner"])
+
+    if mutation == "fuzz":
+        built = _loan_broker_set_base(accounts, vaults)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanBrokerSet", base, client, wallet)
+        return
 
     if mutation == "nonexistent_vault":
         txn = LoanBrokerSet(
@@ -133,20 +154,30 @@ async def loan_broker_delete(
     return await _loan_broker_delete_valid(accounts, loan_brokers, client)
 
 
-async def _loan_broker_delete_valid(
-    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker], client: AsyncJsonRpcClient
-) -> None:
+def _loan_broker_delete_base(
+    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker]
+) -> tuple[LoanBrokerDelete, Wallet] | None:
     if not loan_brokers:
-        return
+        return None
     broker = choice(loan_brokers)
     if broker.owner not in accounts:
-        return
+        return None
     owner = accounts[broker.owner]
     txn = LoanBrokerDelete(
         account=owner.address,
         loan_broker_id=broker.loan_broker_id,
     )
-    await submit_tx("LoanBrokerDelete", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _loan_broker_delete_valid(
+    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker], client: AsyncJsonRpcClient
+) -> None:
+    built = _loan_broker_delete_base(accounts, loan_brokers)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanBrokerDelete", txn, client, wallet)
 
 
 async def _loan_broker_delete_faulty(
@@ -154,7 +185,15 @@ async def _loan_broker_delete_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice(["nonexistent_broker", "non_owner"])
+    mutation = choice(["fuzz", "nonexistent_broker", "non_owner"])
+
+    if mutation == "fuzz":
+        built = _loan_broker_delete_base(accounts, loan_brokers)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanBrokerDelete", base, client, wallet)
+        return
 
     if mutation == "nonexistent_broker":
         acc = choice(list(accounts.values()))
@@ -190,21 +229,31 @@ async def loan_broker_cover_deposit(
     return await _loan_broker_cover_deposit_valid(accounts, loan_brokers, client)
 
 
-async def _loan_broker_cover_deposit_valid(
-    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker], client: AsyncJsonRpcClient
-) -> None:
+def _loan_broker_cover_deposit_base(
+    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker]
+) -> tuple[LoanBrokerCoverDeposit, Wallet] | None:
     if not loan_brokers:
-        return
+        return None
     broker = choice(loan_brokers)
     if broker.owner not in accounts:
-        return
+        return None
     owner = accounts[broker.owner]
     txn = LoanBrokerCoverDeposit(
         account=owner.address,
         loan_broker_id=broker.loan_broker_id,
         amount=params.loan_cover_deposit_amount(),
     )
-    await submit_tx("LoanBrokerCoverDeposit", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _loan_broker_cover_deposit_valid(
+    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker], client: AsyncJsonRpcClient
+) -> None:
+    built = _loan_broker_cover_deposit_base(accounts, loan_brokers)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanBrokerCoverDeposit", txn, client, wallet)
 
 
 async def _loan_broker_cover_deposit_faulty(
@@ -213,7 +262,15 @@ async def _loan_broker_cover_deposit_faulty(
     if not accounts:
         return
     acc = choice(list(accounts.values()))
-    mutation = choice(["nonexistent_broker", "zero_deposit"])
+    mutation = choice(["fuzz", "nonexistent_broker", "zero_deposit"])
+
+    if mutation == "fuzz":
+        built = _loan_broker_cover_deposit_base(accounts, loan_brokers)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanBrokerCoverDeposit", base, client, wallet)
+        return
 
     if mutation == "nonexistent_broker":
         txn = LoanBrokerCoverDeposit(
@@ -260,21 +317,31 @@ def _state_aware_cover_withdraw_amount(broker: LoanBroker) -> str:
     return str(max(1, broker.cover_balance // 4))
 
 
-async def _loan_broker_cover_withdraw_valid(
-    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker], client: AsyncJsonRpcClient
-) -> None:
+def _loan_broker_cover_withdraw_base(
+    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker]
+) -> tuple[LoanBrokerCoverWithdraw, Wallet] | None:
     if not loan_brokers:
-        return
+        return None
     broker = choice(loan_brokers)
     if broker.owner not in accounts:
-        return
+        return None
     owner = accounts[broker.owner]
     txn = LoanBrokerCoverWithdraw(
         account=owner.address,
         loan_broker_id=broker.loan_broker_id,
         amount=_state_aware_cover_withdraw_amount(broker),
     )
-    await submit_tx("LoanBrokerCoverWithdraw", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _loan_broker_cover_withdraw_valid(
+    accounts: dict[str, UserAccount], loan_brokers: list[LoanBroker], client: AsyncJsonRpcClient
+) -> None:
+    built = _loan_broker_cover_withdraw_base(accounts, loan_brokers)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanBrokerCoverWithdraw", txn, client, wallet)
 
 
 async def _loan_broker_cover_withdraw_faulty(
@@ -282,7 +349,15 @@ async def _loan_broker_cover_withdraw_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice(["nonexistent_broker", "excessive_withdrawal", "overdraw"])
+    mutation = choice(["fuzz", "nonexistent_broker", "excessive_withdrawal", "overdraw"])
+
+    if mutation == "fuzz":
+        built = _loan_broker_cover_withdraw_base(accounts, loan_brokers)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanBrokerCoverWithdraw", base, client, wallet)
+        return
 
     if mutation == "overdraw":
         if not loan_brokers:
@@ -441,22 +516,32 @@ async def loan_delete(
     return await _loan_delete_valid(accounts, loans, client)
 
 
-async def _loan_delete_valid(
-    accounts: dict[str, UserAccount], loans: list[Loan], client: AsyncJsonRpcClient
-) -> None:
+def _loan_delete_base(
+    accounts: dict[str, UserAccount], loans: list[Loan]
+) -> tuple[LoanDelete, Wallet] | None:
     if not loans:
-        return
+        return None
     # Prefer paid-off loans; loans with debt return tecHAS_OBLIGATIONS.
     paid_off = [ln for ln in loans if ln.principal <= 0 and ln.borrower in accounts]
     loan = choice(paid_off) if paid_off else choice(loans)
     if loan.borrower not in accounts:
-        return
+        return None
     borrower = accounts[loan.borrower]
     txn = LoanDelete(
         account=borrower.address,
         loan_id=loan.loan_id,
     )
-    await submit_tx("LoanDelete", txn, client, borrower.wallet)
+    return txn, borrower.wallet
+
+
+async def _loan_delete_valid(
+    accounts: dict[str, UserAccount], loans: list[Loan], client: AsyncJsonRpcClient
+) -> None:
+    built = _loan_delete_base(accounts, loans)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanDelete", txn, client, wallet)
 
 
 async def _loan_delete_faulty(
@@ -464,7 +549,15 @@ async def _loan_delete_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice(["nonexistent_loan", "non_borrower"])
+    mutation = choice(["fuzz", "nonexistent_loan", "non_borrower"])
+
+    if mutation == "fuzz":
+        built = _loan_delete_base(accounts, loans)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanDelete", base, client, wallet)
+        return
 
     if mutation == "nonexistent_loan":
         acc = choice(list(accounts.values()))
@@ -512,25 +605,37 @@ def _state_aware_manage_flag(loan: Loan) -> LoanManageFlag:
     return choice([LoanManageFlag.TF_LOAN_IMPAIR, LoanManageFlag.TF_LOAN_DEFAULT])
 
 
-async def _loan_manage_valid(
+def _loan_manage_base(
     accounts: dict[str, UserAccount],
     loan_brokers: list[LoanBroker],
     loans: list[Loan],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[LoanManage, Wallet] | None:
     if not loans or not loan_brokers:
-        return
+        return None
     loan = choice(loans)
     broker = next((b for b in loan_brokers if b.loan_broker_id == loan.loan_broker_id), None)
     if not broker or broker.owner not in accounts:
-        return
+        return None
     owner = accounts[broker.owner]
     txn = LoanManage(
         account=owner.address,
         loan_id=loan.loan_id,
         flags=_state_aware_manage_flag(loan),
     )
-    await submit_tx("LoanManage", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _loan_manage_valid(
+    accounts: dict[str, UserAccount],
+    loan_brokers: list[LoanBroker],
+    loans: list[Loan],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _loan_manage_base(accounts, loan_brokers, loans)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanManage", txn, client, wallet)
 
 
 async def _loan_manage_faulty(
@@ -541,7 +646,15 @@ async def _loan_manage_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice(["nonexistent_loan", "non_broker_owner"])
+    mutation = choice(["fuzz", "nonexistent_loan", "non_broker_owner"])
+
+    if mutation == "fuzz":
+        built = _loan_manage_base(accounts, loan_brokers, loans)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanManage", base, client, wallet)
+        return
 
     if mutation == "nonexistent_loan":
         acc = choice(list(accounts.values()))
@@ -601,21 +714,31 @@ def _state_aware_pay_amount(loan: Loan) -> str:
     return params.loan_pay_amount()
 
 
-async def _loan_pay_valid(
-    accounts: dict[str, UserAccount], loans: list[Loan], client: AsyncJsonRpcClient
-) -> None:
+def _loan_pay_base(
+    accounts: dict[str, UserAccount], loans: list[Loan]
+) -> tuple[LoanPay, Wallet] | None:
     if not loans:
-        return
+        return None
     loan = choice(loans)
     if loan.borrower not in accounts:
-        return
+        return None
     borrower = accounts[loan.borrower]
     txn = LoanPay(
         account=borrower.address,
         loan_id=loan.loan_id,
         amount=_state_aware_pay_amount(loan),
     )
-    await submit_tx("LoanPay", txn, client, borrower.wallet)
+    return txn, borrower.wallet
+
+
+async def _loan_pay_valid(
+    accounts: dict[str, UserAccount], loans: list[Loan], client: AsyncJsonRpcClient
+) -> None:
+    built = _loan_pay_base(accounts, loans)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("LoanPay", txn, client, wallet)
 
 
 async def _loan_pay_faulty(
@@ -623,7 +746,15 @@ async def _loan_pay_faulty(
 ) -> None:
     if not accounts:
         return
-    mutation = choice(["nonexistent_loan", "zero_payment"])
+    mutation = choice(["fuzz", "nonexistent_loan", "zero_payment"])
+
+    if mutation == "fuzz":
+        built = _loan_pay_base(accounts, loans)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("LoanPay", base, client, wallet)
+        return
 
     if mutation == "nonexistent_loan":
         acc = choice(list(accounts.values()))

--- a/workload/src/workload/transactions/mpt.py
+++ b/workload/src/workload/transactions/mpt.py
@@ -9,11 +9,13 @@ from xrpl.models.transactions import (
 )
 from xrpl.models.transactions.mptoken_issuance_create import MPTokenIssuanceCreateFlag
 from xrpl.models.transactions.mptoken_issuance_set import MPTokenIssuanceSetFlag
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import MPTokenIssuance, UserAccount
 from workload.randoms import choice, random
-from workload.submit import submit_tx
+from workload.submit import submit_raw, submit_tx
 
 # ── Create ───────────────────────────────────────────────────────────
 
@@ -23,16 +25,18 @@ async def mpt_create(
     mpt_issuances: list[MPTokenIssuance],
     client: AsyncJsonRpcClient,
 ) -> None:
+    if params.should_send_faulty():
+        return await _mpt_create_faulty(accounts, mpt_issuances, client)
     return await _mpt_create_valid(accounts, mpt_issuances, client)
 
 
-async def _mpt_create_valid(
+def _mpt_create_base(
     accounts: dict[str, UserAccount],
-    mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
-    src_address = choice(list(accounts))
-    src = accounts[src_address]
+) -> tuple[MPTokenIssuanceCreate, Wallet] | None:
+    """Valid MPTokenIssuanceCreate + wallet; shared by valid and fuzz."""
+    if not accounts:
+        return None
+    src = accounts[choice(list(accounts))]
     flags = MPTokenIssuanceCreateFlag.TF_MPT_CAN_LOCK
     if random() < 0.30:
         flags |= MPTokenIssuanceCreateFlag.TF_MPT_REQUIRE_AUTH
@@ -44,7 +48,49 @@ async def _mpt_create_valid(
         mptoken_metadata=params.mpt_metadata(),
         flags=flags,
     )
-    await submit_tx("MPTokenIssuanceCreate", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _mpt_create_valid(
+    accounts: dict[str, UserAccount],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _mpt_create_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("MPTokenIssuanceCreate", txn, client, wallet)
+
+
+async def _mpt_create_faulty(
+    accounts: dict[str, UserAccount],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _mpt_create_base(accounts)
+    if built is None:
+        return
+    base, wallet = built
+
+    # A fresh issuance always succeeds, so no reliable tec vector exists here;
+    # both curated mutations are temMALFORMED malformations xrpl-py forbids.
+    mutation = choice(["fuzz", "oversize_metadata", "zero_max_amount"])
+    if mutation == "fuzz":
+        await submit_fuzzed("MPTokenIssuanceCreate", base, client, wallet)
+        return
+
+    if mutation == "oversize_metadata":
+        # MPTokenMetadata > 1024 bytes -> temMALFORMED.
+        def _mutate(d: dict) -> None:
+            d["MPTokenMetadata"] = "AB" * 1025
+
+    else:  # zero_max_amount -> temMALFORMED (MaximumAmount must be positive).
+
+        def _mutate(d: dict) -> None:
+            d["MaximumAmount"] = "0"
+
+    await submit_raw("MPTokenIssuanceCreate", base, client, wallet, _mutate)
 
 
 # ── Authorize ────────────────────────────────────────────────────────
@@ -60,40 +106,48 @@ async def mpt_authorize(
     return await _mpt_authorize_valid(accounts, mpt_issuances, client)
 
 
-async def _mpt_authorize_valid(
+def _mpt_authorize_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[MPTokenAuthorize, Wallet] | None:
+    """Valid MPTokenAuthorize (holder opt-in / issuer auth) + wallet; shared by valid and fuzz."""
     if not mpt_issuances:
-        return
+        return None
     mpt = choice(mpt_issuances)
     if mpt.issuer not in accounts:
-        return
-
+        return None
     other_accounts = [a for a in accounts if a != mpt.issuer]
     if not other_accounts:
-        return
+        return None
 
-    mode = choice(["holder_optin", "issuer_auth"])
-
-    if mode == "holder_optin":
+    if choice(["holder_optin", "issuer_auth"]) == "holder_optin":
         # opt-in works for any MPT; issuer_auth needs TF_MPT_REQUIRE_AUTH
         holder = accounts[choice(other_accounts)]
         txn = MPTokenAuthorize(
             account=holder.address,
             mptoken_issuance_id=mpt.mpt_issuance_id,
         )
-        await submit_tx("MPTokenAuthorize", txn, client, holder.wallet)
-    else:
-        issuer = accounts[mpt.issuer]
-        holder_id = choice(other_accounts)
-        txn = MPTokenAuthorize(
-            account=issuer.address,
-            mptoken_issuance_id=mpt.mpt_issuance_id,
-            holder=holder_id,
-        )
-        await submit_tx("MPTokenAuthorize", txn, client, issuer.wallet)
+        return txn, holder.wallet
+    issuer = accounts[mpt.issuer]
+    holder_id = choice(other_accounts)
+    txn = MPTokenAuthorize(
+        account=issuer.address,
+        mptoken_issuance_id=mpt.mpt_issuance_id,
+        holder=holder_id,
+    )
+    return txn, issuer.wallet
+
+
+async def _mpt_authorize_valid(
+    accounts: dict[str, UserAccount],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _mpt_authorize_base(accounts, mpt_issuances)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("MPTokenAuthorize", txn, client, wallet)
 
 
 async def _mpt_authorize_faulty(
@@ -101,7 +155,55 @@ async def _mpt_authorize_faulty(
     mpt_issuances: list[MPTokenIssuance],
     client: AsyncJsonRpcClient,
 ) -> None:
-    pass  # TODO: fault injection
+    built = _mpt_authorize_base(accounts, mpt_issuances)
+    if built is None:
+        return
+    base, wallet = built
+
+    mutation = choice(["fuzz", "fake_issuance", "self_authorize", "duplicate_optin"])
+    if mutation == "fuzz":
+        await submit_fuzzed("MPTokenAuthorize", base, client, wallet)
+        return
+
+    if mutation == "fake_issuance":
+        # Opt in to an issuance that does not exist -> tecOBJECT_NOT_FOUND.
+        if not accounts:
+            return
+        holder = choice(list(accounts.values()))
+        txn = MPTokenAuthorize(
+            account=holder.address,
+            mptoken_issuance_id=params.fake_mpt_id(),
+        )
+        await submit_tx("MPTokenAuthorize", txn, client, holder.wallet)
+        return
+
+    mpt = choice(mpt_issuances)
+    if mpt.issuer not in accounts:
+        return
+
+    if mutation == "self_authorize":
+        # Issuer names itself as Holder -> temMALFORMED.
+        issuer = accounts[mpt.issuer]
+        txn = MPTokenAuthorize(
+            account=issuer.address,
+            mptoken_issuance_id=mpt.mpt_issuance_id,
+            holder=issuer.address,
+        )
+        await submit_tx("MPTokenAuthorize", txn, client, issuer.wallet)
+        return
+
+    # duplicate_optin: holder already authorized re-opts in -> tecDUPLICATE.
+    if not mpt.holders:
+        return
+    held = choice(list(mpt.holders))
+    if held not in accounts:
+        return
+    holder = accounts[held]
+    txn = MPTokenAuthorize(
+        account=holder.address,
+        mptoken_issuance_id=mpt.mpt_issuance_id,
+    )
+    await submit_tx("MPTokenAuthorize", txn, client, holder.wallet)
 
 
 # ── Set ──────────────────────────────────────────────────────────────
@@ -117,16 +219,16 @@ async def mpt_issuance_set(
     return await _mpt_issuance_set_valid(accounts, mpt_issuances, client)
 
 
-async def _mpt_issuance_set_valid(
+def _mpt_issuance_set_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[MPTokenIssuanceSet, Wallet] | None:
+    """Valid MPTokenIssuanceSet (issuer lock/unlock) + wallet; shared by valid and fuzz."""
     if not mpt_issuances:
-        return
+        return None
     mpt = choice(mpt_issuances)
     if mpt.issuer not in accounts:
-        return
+        return None
     issuer = accounts[mpt.issuer]
     flag = choice(list(MPTokenIssuanceSetFlag))
     txn = MPTokenIssuanceSet(
@@ -134,7 +236,19 @@ async def _mpt_issuance_set_valid(
         mptoken_issuance_id=mpt.mpt_issuance_id,
         flags=flag,
     )
-    await submit_tx("MPTokenIssuanceSet", txn, client, issuer.wallet)
+    return txn, issuer.wallet
+
+
+async def _mpt_issuance_set_valid(
+    accounts: dict[str, UserAccount],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _mpt_issuance_set_base(accounts, mpt_issuances)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("MPTokenIssuanceSet", txn, client, wallet)
 
 
 async def _mpt_issuance_set_faulty(
@@ -142,7 +256,43 @@ async def _mpt_issuance_set_faulty(
     mpt_issuances: list[MPTokenIssuance],
     client: AsyncJsonRpcClient,
 ) -> None:
-    pass  # TODO: fault injection
+    built = _mpt_issuance_set_base(accounts, mpt_issuances)
+    if built is None:
+        return
+    base, wallet = built
+
+    mutation = choice(["fuzz", "fake_issuance", "non_issuer"])
+    if mutation == "fuzz":
+        await submit_fuzzed("MPTokenIssuanceSet", base, client, wallet)
+        return
+
+    flag = choice(list(MPTokenIssuanceSetFlag))
+
+    if mutation == "fake_issuance":
+        # Set flags on an issuance that does not exist -> tecOBJECT_NOT_FOUND.
+        if not accounts:
+            return
+        src = choice(list(accounts.values()))
+        txn = MPTokenIssuanceSet(
+            account=src.address,
+            mptoken_issuance_id=params.fake_mpt_id(),
+            flags=flag,
+        )
+        await submit_tx("MPTokenIssuanceSet", txn, client, src.wallet)
+        return
+
+    # non_issuer: an account other than the issuer sets flags -> tecNO_PERMISSION.
+    mpt = choice(mpt_issuances)
+    others = [a for a in accounts if a != mpt.issuer]
+    if not others:
+        return
+    src = accounts[choice(others)]
+    txn = MPTokenIssuanceSet(
+        account=src.address,
+        mptoken_issuance_id=mpt.mpt_issuance_id,
+        flags=flag,
+    )
+    await submit_tx("MPTokenIssuanceSet", txn, client, src.wallet)
 
 
 # ── Destroy ──────────────────────────────────────────────────────────
@@ -158,22 +308,34 @@ async def mpt_destroy(
     return await _mpt_destroy_valid(accounts, mpt_issuances, client)
 
 
-async def _mpt_destroy_valid(
+def _mpt_destroy_base(
     accounts: dict[str, UserAccount],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[MPTokenIssuanceDestroy, Wallet] | None:
+    """Valid MPTokenIssuanceDestroy (issuer destroys own issuance) + wallet."""
     if not mpt_issuances:
-        return
+        return None
     mpt = choice(mpt_issuances)
     if mpt.issuer not in accounts:
-        return
+        return None
     issuer = accounts[mpt.issuer]
     txn = MPTokenIssuanceDestroy(
         account=issuer.address,
         mptoken_issuance_id=mpt.mpt_issuance_id,
     )
-    await submit_tx("MPTokenIssuanceDestroy", txn, client, issuer.wallet)
+    return txn, issuer.wallet
+
+
+async def _mpt_destroy_valid(
+    accounts: dict[str, UserAccount],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _mpt_destroy_base(accounts, mpt_issuances)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("MPTokenIssuanceDestroy", txn, client, wallet)
 
 
 async def _mpt_destroy_faulty(
@@ -181,4 +343,53 @@ async def _mpt_destroy_faulty(
     mpt_issuances: list[MPTokenIssuance],
     client: AsyncJsonRpcClient,
 ) -> None:
-    pass  # TODO: fault injection
+    built = _mpt_destroy_base(accounts, mpt_issuances)
+    if built is None:
+        return
+    base, wallet = built
+
+    mutation = choice(["fuzz", "fake_issuance", "non_issuer", "has_obligations"])
+    if mutation == "fuzz":
+        await submit_fuzzed("MPTokenIssuanceDestroy", base, client, wallet)
+        return
+
+    if mutation == "fake_issuance":
+        # Destroy an issuance that does not exist -> tecOBJECT_NOT_FOUND.
+        if not accounts:
+            return
+        src = choice(list(accounts.values()))
+        txn = MPTokenIssuanceDestroy(
+            account=src.address,
+            mptoken_issuance_id=params.fake_mpt_id(),
+        )
+        await submit_tx("MPTokenIssuanceDestroy", txn, client, src.wallet)
+        return
+
+    mpt = choice(mpt_issuances)
+    if mpt.issuer not in accounts:
+        return
+
+    if mutation == "non_issuer":
+        # Non-issuer tries to destroy -> tecNO_PERMISSION.
+        others = [a for a in accounts if a != mpt.issuer]
+        if not others:
+            return
+        src = accounts[choice(others)]
+        txn = MPTokenIssuanceDestroy(
+            account=src.address,
+            mptoken_issuance_id=mpt.mpt_issuance_id,
+        )
+        await submit_tx("MPTokenIssuanceDestroy", txn, client, src.wallet)
+        return
+
+    # has_obligations: destroy an issuance that still has holders -> tecHAS_OBLIGATIONS.
+    with_holders = [m for m in mpt_issuances if m.holders and m.issuer in accounts]
+    if not with_holders:
+        return
+    mpt = choice(with_holders)
+    issuer = accounts[mpt.issuer]
+    txn = MPTokenIssuanceDestroy(
+        account=issuer.address,
+        mptoken_issuance_id=mpt.mpt_issuance_id,
+    )
+    await submit_tx("MPTokenIssuanceDestroy", txn, client, issuer.wallet)

--- a/workload/src/workload/transactions/nft.py
+++ b/workload/src/workload/transactions/nft.py
@@ -12,11 +12,13 @@ from xrpl.models.transactions import (
     NFTokenModify,
 )
 from xrpl.models.transactions.transaction import Memo
+from xrpl.wallet import Wallet
 
 from workload import logging, params
+from workload.fuzz import submit_fuzzed
 from workload.models import NFT, NFTOffer, UserAccount
 from workload.randoms import choice, random
-from workload.submit import submit_tx
+from workload.submit import submit_raw, submit_tx
 
 log = logging.getLogger(__name__)
 
@@ -32,11 +34,13 @@ async def nftoken_mint(
     return await _nftoken_mint_valid(accounts, nfts, client)
 
 
-async def _nftoken_mint_valid(
-    accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
-) -> None:
-    account_id = choice(list(accounts))
-    account = accounts[account_id]
+def _nftoken_mint_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[NFTokenMint, Wallet] | None:
+    """Valid NFTokenMint + wallet; shared by valid and fuzz."""
+    if not accounts:
+        return None
+    account = choice(list(accounts.values()))
     # ~30% mutable so NFTokenModify has targets
     flags = NFTokenMintFlag.TF_TRANSFERABLE
     if random() < 0.30:
@@ -48,7 +52,17 @@ async def _nftoken_mint_valid(
         flags=flags,
         memos=[Memo(memo_data=params.nft_memo().encode("utf-8").hex())],
     )
-    await submit_tx("NFTokenMint", txn, client, account.wallet)
+    return txn, account.wallet
+
+
+async def _nftoken_mint_valid(
+    accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
+) -> None:
+    built = _nftoken_mint_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("NFTokenMint", txn, client, wallet)
 
 
 async def _nftoken_mint_faulty(
@@ -57,9 +71,17 @@ async def _nftoken_mint_faulty(
     if len(accounts) < 2:
         return
     acct_list = list(accounts.values())
-    src = choice(acct_list)
-    # Set issuer to another account that hasn't authorized us → tecNO_PERMISSION
+
+    if choice(["foreign_issuer", "fuzz"]) == "fuzz":
+        built = _nftoken_mint_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("NFTokenMint", base, client, wallet)
+        return
+
     # issuer hasn't authorized src as minter → tecNO_PERMISSION
+    src = choice(acct_list)
     other = choice([a for a in acct_list if a.address != src.address])
     txn = NFTokenMint(
         account=src.address,
@@ -83,21 +105,58 @@ async def nftoken_burn(
     return await _nftoken_burn_valid(accounts, nfts, client)
 
 
+def _nftoken_burn_base(
+    accounts: dict[str, UserAccount], nfts: list[NFT]
+) -> tuple[NFTokenBurn, Wallet] | None:
+    """Valid NFTokenBurn of an owned NFT + wallet; shared by valid and fuzz."""
+    nft = choice(nfts)
+    if nft.owner not in accounts:
+        return None
+    owner = accounts[nft.owner]
+    txn = NFTokenBurn(account=owner.address, nftoken_id=nft.nftoken_id)
+    return txn, owner.wallet
+
+
 async def _nftoken_burn_valid(
     accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
 ) -> None:
-    nft = choice(nfts)
-    if nft.owner not in accounts:
+    built = _nftoken_burn_base(accounts, nfts)
+    if built is None:
         return
-    owner = accounts[nft.owner]
-    txn = NFTokenBurn(account=owner.address, nftoken_id=nft.nftoken_id)
-    await submit_tx("NFTokenBurn", txn, client, owner.wallet)
+    txn, wallet = built
+    await submit_tx("NFTokenBurn", txn, client, wallet)
 
 
 async def _nftoken_burn_faulty(
     accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
 ) -> None:
-    pass  # TODO: fault injection
+    if not accounts:
+        return
+
+    mutation = choice(["nonexistent", "non_owner", "fuzz"])
+    if mutation == "fuzz":
+        built = _nftoken_burn_base(accounts, nfts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("NFTokenBurn", base, client, wallet)
+        return
+
+    if mutation == "nonexistent":
+        # Fake NFTokenID → tecNO_ENTRY.
+        src = choice(list(accounts.values()))
+        txn = NFTokenBurn(account=src.address, nftoken_id=params.fake_id())
+        await submit_tx("NFTokenBurn", txn, client, src.wallet)
+        return
+
+    # non_owner: burn a tracked NFT the submitter doesn't own → tecNO_PERMISSION.
+    nft = choice(nfts)
+    non_owners = [a for a in accounts.values() if a.address != nft.owner]
+    if not non_owners:
+        return
+    src = choice(non_owners)
+    txn = NFTokenBurn(account=src.address, nftoken_id=nft.nftoken_id)
+    await submit_tx("NFTokenBurn", txn, client, src.wallet)
 
 
 # ── Modify ───────────────────────────────────────────────────────────
@@ -113,25 +172,83 @@ async def nftoken_modify(
     return await _nftoken_modify_valid(accounts, nfts, client)
 
 
-async def _nftoken_modify_valid(
-    accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
-) -> None:
+def _nftoken_modify_base(
+    accounts: dict[str, UserAccount], nfts: list[NFT]
+) -> tuple[NFTokenModify, Wallet] | None:
+    """Valid NFTokenModify of an owned NFT + wallet; shared by valid and fuzz."""
     nft = choice(nfts)
     if nft.owner not in accounts:
-        return
+        return None
     owner = accounts[nft.owner]
     txn = NFTokenModify(
         account=owner.address,
         nftoken_id=nft.nftoken_id,
         uri=params.nft_uri(),
     )
-    await submit_tx("NFTokenModify", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _nftoken_modify_valid(
+    accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
+) -> None:
+    built = _nftoken_modify_base(accounts, nfts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("NFTokenModify", txn, client, wallet)
 
 
 async def _nftoken_modify_faulty(
     accounts: dict[str, UserAccount], nfts: list[NFT], client: AsyncJsonRpcClient
 ) -> None:
-    pass  # TODO: fault injection
+    if not accounts:
+        return
+
+    mutation = choice(["nonexistent", "non_owner", "oversize_uri", "fuzz"])
+    if mutation == "fuzz":
+        built = _nftoken_modify_base(accounts, nfts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("NFTokenModify", base, client, wallet)
+        return
+
+    if mutation == "nonexistent":
+        # Fake NFTokenID → tecNO_ENTRY.
+        src = choice(list(accounts.values()))
+        txn = NFTokenModify(
+            account=src.address,
+            nftoken_id=params.fake_id(),
+            uri=params.nft_uri(),
+        )
+        await submit_tx("NFTokenModify", txn, client, src.wallet)
+        return
+
+    if mutation == "oversize_uri":
+        # URI > 256 bytes → temMALFORMED (xrpl-py rejects at construction).
+        built = _nftoken_modify_base(accounts, nfts)
+        if built is None:
+            return
+        base, wallet = built
+
+        def _mutate(d: dict) -> None:
+            d["URI"] = "ab" * 300
+
+        await submit_raw("NFTokenModify", base, client, wallet, _mutate)
+        return
+
+    # non_owner: modify a tracked NFT the submitter doesn't own → tecNO_PERMISSION.
+    nft = choice(nfts)
+    non_owners = [a for a in accounts.values() if a.address != nft.owner]
+    if not non_owners:
+        return
+    src = choice(non_owners)
+    txn = NFTokenModify(
+        account=src.address,
+        nftoken_id=nft.nftoken_id,
+        uri=params.nft_uri(),
+    )
+    await submit_tx("NFTokenModify", txn, client, src.wallet)
 
 
 # ── Create Offer ─────────────────────────────────────────────────────
@@ -150,37 +267,45 @@ async def nftoken_create_offer(
     return await _nftoken_create_offer_valid(accounts, nfts, nft_offers, client)
 
 
-async def _nftoken_create_offer_valid(
-    accounts: dict[str, UserAccount],
-    nfts: list[NFT],
-    nft_offers: list[NFTOffer],
-    client: AsyncJsonRpcClient,
-) -> None:
+def _nftoken_create_offer_base(
+    accounts: dict[str, UserAccount], nfts: list[NFT]
+) -> tuple[NFTokenCreateOffer, Wallet] | None:
+    """Valid NFTokenCreateOffer (sell or buy) + wallet; shared by valid and fuzz."""
     nft = choice(nfts)
     if nft.owner not in accounts:
-        return
+        return None
     owner = accounts[nft.owner]
-    is_sell = choice([True, False])
-    if is_sell:
+    if choice([True, False]):
         txn = NFTokenCreateOffer(
             account=owner.address,
             nftoken_id=nft.nftoken_id,
             amount=params.nft_offer_amount(),
             flags=NFTokenCreateOfferFlag.TF_SELL_NFTOKEN,
         )
-        wallet = owner.wallet
-    else:
-        other_accounts = [a for a in accounts if a != nft.owner]
-        if not other_accounts:
-            return
-        buyer = accounts[choice(other_accounts)]
-        txn = NFTokenCreateOffer(
-            account=buyer.address,
-            nftoken_id=nft.nftoken_id,
-            amount=params.nft_offer_amount(),
-            owner=nft.owner,
-        )
-        wallet = buyer.wallet
+        return txn, owner.wallet
+    other_accounts = [a for a in accounts if a != nft.owner]
+    if not other_accounts:
+        return None
+    buyer = accounts[choice(other_accounts)]
+    txn = NFTokenCreateOffer(
+        account=buyer.address,
+        nftoken_id=nft.nftoken_id,
+        amount=params.nft_offer_amount(),
+        owner=nft.owner,
+    )
+    return txn, buyer.wallet
+
+
+async def _nftoken_create_offer_valid(
+    accounts: dict[str, UserAccount],
+    nfts: list[NFT],
+    nft_offers: list[NFTOffer],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _nftoken_create_offer_base(accounts, nfts)
+    if built is None:
+        return
+    txn, wallet = built
     await submit_tx("NFTokenCreateOffer", txn, client, wallet)
 
 
@@ -190,7 +315,43 @@ async def _nftoken_create_offer_faulty(
     nft_offers: list[NFTOffer],
     client: AsyncJsonRpcClient,
 ) -> None:
-    pass  # TODO: fault injection
+    if not accounts:
+        return
+
+    mutation = choice(["nonexistent", "sell_not_owned", "fuzz"])
+    if mutation == "fuzz":
+        built = _nftoken_create_offer_base(accounts, nfts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("NFTokenCreateOffer", base, client, wallet)
+        return
+
+    if mutation == "nonexistent":
+        # Sell offer on a fake NFTokenID → tecNO_ENTRY.
+        src = choice(list(accounts.values()))
+        txn = NFTokenCreateOffer(
+            account=src.address,
+            nftoken_id=params.fake_id(),
+            amount=params.nft_offer_amount(),
+            flags=NFTokenCreateOfferFlag.TF_SELL_NFTOKEN,
+        )
+        await submit_tx("NFTokenCreateOffer", txn, client, src.wallet)
+        return
+
+    # sell_not_owned: sell offer on a tracked NFT the submitter doesn't own → tecNO_PERMISSION.
+    nft = choice(nfts)
+    non_owners = [a for a in accounts.values() if a.address != nft.owner]
+    if not non_owners:
+        return
+    src = choice(non_owners)
+    txn = NFTokenCreateOffer(
+        account=src.address,
+        nftoken_id=nft.nftoken_id,
+        amount=params.nft_offer_amount(),
+        flags=NFTokenCreateOfferFlag.TF_SELL_NFTOKEN,
+    )
+    await submit_tx("NFTokenCreateOffer", txn, client, src.wallet)
 
 
 # ── Cancel Offer ─────────────────────────────────────────────────────
@@ -206,18 +367,29 @@ async def nftoken_cancel_offer(
     return await _nftoken_cancel_offer_valid(accounts, nft_offers, client)
 
 
-async def _nftoken_cancel_offer_valid(
-    accounts: dict[str, UserAccount], nft_offers: list[NFTOffer], client: AsyncJsonRpcClient
-) -> None:
+def _nftoken_cancel_offer_base(
+    accounts: dict[str, UserAccount], nft_offers: list[NFTOffer]
+) -> tuple[NFTokenCancelOffer, Wallet] | None:
+    """Valid NFTokenCancelOffer of a tracked offer + wallet; shared by valid and fuzz."""
     offer = choice(nft_offers)
     if offer.creator not in accounts:
-        return
+        return None
     creator = accounts[offer.creator]
     txn = NFTokenCancelOffer(
         account=creator.address,
         nftoken_offers=[offer.offer_id],
     )
-    await submit_tx("NFTokenCancelOffer", txn, client, creator.wallet)
+    return txn, creator.wallet
+
+
+async def _nftoken_cancel_offer_valid(
+    accounts: dict[str, UserAccount], nft_offers: list[NFTOffer], client: AsyncJsonRpcClient
+) -> None:
+    built = _nftoken_cancel_offer_base(accounts, nft_offers)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("NFTokenCancelOffer", txn, client, wallet)
 
 
 async def _nftoken_cancel_offer_faulty(
@@ -225,8 +397,17 @@ async def _nftoken_cancel_offer_faulty(
 ) -> None:
     if not accounts:
         return
+
+    if choice(["nonexistent", "fuzz"]) == "fuzz":
+        built = _nftoken_cancel_offer_base(accounts, nft_offers)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("NFTokenCancelOffer", base, client, wallet)
+        return
+
+    # Non-existent offer id no-ops → tesSUCCESS (cancel ignores unknown ids).
     src = choice(list(accounts.values()))
-    # Non-existent offer → tecOBJECT_NOT_FOUND.
     txn = NFTokenCancelOffer(
         account=src.address,
         nftoken_offers=[params.fake_id()],
@@ -250,33 +431,42 @@ async def nftoken_accept_offer(
     return await _nftoken_accept_offer_valid(accounts, nfts, nft_offers, client)
 
 
+def _nftoken_accept_offer_base(
+    accounts: dict[str, UserAccount], nfts: list[NFT], nft_offers: list[NFTOffer]
+) -> tuple[NFTokenAcceptOffer, Wallet] | None:
+    """Valid NFTokenAcceptOffer (counterparty of a tracked offer) + wallet."""
+    offer = choice(nft_offers)
+    if offer.is_sell:
+        other_accounts = [a for a in accounts if a != offer.creator]
+        if not other_accounts:
+            return None
+        buyer = accounts[choice(other_accounts)]
+        txn = NFTokenAcceptOffer(
+            account=buyer.address,
+            nftoken_sell_offer=offer.offer_id,
+        )
+        return txn, buyer.wallet
+    nft = next((n for n in nfts if n.nftoken_id == offer.nftoken_id), None)
+    if not nft or nft.owner not in accounts:
+        return None
+    owner = accounts[nft.owner]
+    txn = NFTokenAcceptOffer(
+        account=owner.address,
+        nftoken_buy_offer=offer.offer_id,
+    )
+    return txn, owner.wallet
+
+
 async def _nftoken_accept_offer_valid(
     accounts: dict[str, UserAccount],
     nfts: list[NFT],
     nft_offers: list[NFTOffer],
     client: AsyncJsonRpcClient,
 ) -> None:
-    offer = choice(nft_offers)
-    if offer.is_sell:
-        other_accounts = [a for a in accounts if a != offer.creator]
-        if not other_accounts:
-            return
-        buyer = accounts[choice(other_accounts)]
-        txn = NFTokenAcceptOffer(
-            account=buyer.address,
-            nftoken_sell_offer=offer.offer_id,
-        )
-        wallet = buyer.wallet
-    else:
-        nft = next((n for n in nfts if n.nftoken_id == offer.nftoken_id), None)
-        if not nft or nft.owner not in accounts:
-            return
-        owner = accounts[nft.owner]
-        txn = NFTokenAcceptOffer(
-            account=owner.address,
-            nftoken_buy_offer=offer.offer_id,
-        )
-        wallet = owner.wallet
+    built = _nftoken_accept_offer_base(accounts, nfts, nft_offers)
+    if built is None:
+        return
+    txn, wallet = built
     await submit_tx("NFTokenAcceptOffer", txn, client, wallet)
 
 
@@ -286,4 +476,41 @@ async def _nftoken_accept_offer_faulty(
     nft_offers: list[NFTOffer],
     client: AsyncJsonRpcClient,
 ) -> None:
-    pass  # TODO: fault injection
+    if not accounts:
+        return
+
+    mutation = choice(["nonexistent", "accept_own", "fuzz"])
+    if mutation == "fuzz":
+        built = _nftoken_accept_offer_base(accounts, nfts, nft_offers)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("NFTokenAcceptOffer", base, client, wallet)
+        return
+
+    if mutation == "nonexistent":
+        # Accept a fake sell offer → tecOBJECT_NOT_FOUND.
+        src = choice(list(accounts.values()))
+        txn = NFTokenAcceptOffer(
+            account=src.address,
+            nftoken_sell_offer=params.fake_id(),
+        )
+        await submit_tx("NFTokenAcceptOffer", txn, client, src.wallet)
+        return
+
+    # accept_own: creator accepts their own tracked offer → tecCANT_ACCEPT_OWN_NFTOKEN_OFFER.
+    offer = choice(nft_offers)
+    if offer.creator not in accounts:
+        return
+    creator = accounts[offer.creator]
+    if offer.is_sell:
+        txn = NFTokenAcceptOffer(
+            account=creator.address,
+            nftoken_sell_offer=offer.offer_id,
+        )
+    else:
+        txn = NFTokenAcceptOffer(
+            account=creator.address,
+            nftoken_buy_offer=offer.offer_id,
+        )
+    await submit_tx("NFTokenAcceptOffer", txn, client, creator.wallet)

--- a/workload/src/workload/transactions/offers.py
+++ b/workload/src/workload/transactions/offers.py
@@ -8,8 +8,10 @@ from xrpl.models import IssuedCurrencyAmount as IOUAmount
 from xrpl.models.currencies import IssuedCurrency, MPTCurrency
 from xrpl.models.transactions import OfferCancel, OfferCreate
 from xrpl.models.transactions.offer_create import OfferCreateFlag
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import AMM, TrustLine, UserAccount
 from workload.randoms import choice, randint, random, sample
 from workload.submit import submit_tx
@@ -100,36 +102,43 @@ async def offer_create(
     return await _offer_create_valid(accounts, amms, trust_lines, client)
 
 
+def _offer_create_base(
+    accounts: dict[str, UserAccount],
+    amms: list[AMM],
+    trust_lines: list[TrustLine],
+) -> tuple[OfferCreate, Wallet] | None:
+    """Valid OfferCreate against an IOU/XRP AMM pair + wallet; shared by valid and fuzz."""
+    iou_amms = _non_mpt_amms(amms)
+    if not iou_amms:
+        return None
+    amm = choice(iou_amms)
+    src = _find_account_for_amm(accounts, trust_lines, amm)
+    if not src:
+        return None
+    pair = _make_offer_amounts(amm)
+    if not pair:
+        return None
+    taker_gets, taker_pays = pair
+    txn = OfferCreate(
+        account=src.address,
+        taker_gets=taker_gets,
+        taker_pays=taker_pays,
+        flags=_random_flag(),
+    )
+    return txn, src.wallet
+
+
 async def _offer_create_valid(
     accounts: dict[str, UserAccount],
     amms: list[AMM],
     trust_lines: list[TrustLine],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if not amms:
+    built = _offer_create_base(accounts, amms, trust_lines)
+    if built is None:
         return
-
-    iou_amms = _non_mpt_amms(amms)
-    if not iou_amms:
-        return
-
-    amm = choice(iou_amms)
-    src = _find_account_for_amm(accounts, trust_lines, amm)
-    if not src:
-        return
-
-    pair = _make_offer_amounts(amm)
-    if not pair:
-        return
-    taker_gets, taker_pays = pair
-    flag = _random_flag()
-    txn = OfferCreate(
-        account=src.address,
-        taker_gets=taker_gets,
-        taker_pays=taker_pays,
-        flags=flag,
-    )
-    await submit_tx("OfferCreate", txn, client, src.wallet)
+    txn, wallet = built
+    await submit_tx("OfferCreate", txn, client, wallet)
 
 
 async def _offer_create_faulty(
@@ -149,8 +158,17 @@ async def _offer_create_faulty(
             "zero_amount",
             "negative_iou_amount",
             "crossed_offer",
+            "fuzz",
         ]
     )
+    if mutation == "fuzz":
+        built = _offer_create_base(accounts, amms, trust_lines)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("OfferCreate", base, client, wallet)
+        return
+
     if mutation == "non_existent_asset":
         fake = _fake_iou()
         taker_gets = _iou_amount(fake, str(randint(1, 1_000)))
@@ -234,8 +252,23 @@ async def offer_cancel(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _offer_cancel_faulty(accounts, client)
+        return await _offer_cancel_faulty(accounts, offers, client)
     return await _offer_cancel_valid(accounts, offers, client)
+
+
+def _offer_cancel_base(
+    accounts: dict[str, UserAccount],
+    offers: list[dict],
+) -> tuple[OfferCancel, Wallet] | None:
+    """Valid OfferCancel of a tracked resting offer + wallet; shared by valid and fuzz."""
+    if not offers:
+        return None
+    offer = choice(offers)
+    acct = accounts.get(offer["account"])
+    if not acct:
+        return None
+    txn = OfferCancel(account=acct.address, offer_sequence=offer["sequence"])
+    return txn, acct.wallet
 
 
 async def _offer_cancel_valid(
@@ -243,22 +276,16 @@ async def _offer_cancel_valid(
     offers: list[dict],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if not offers:
+    built = _offer_cancel_base(accounts, offers)
+    if built is None:
         return
-    offer = choice(offers)
-    acct = accounts.get(offer["account"])
-    if not acct:
-        return
-
-    txn = OfferCancel(
-        account=acct.address,
-        offer_sequence=offer["sequence"],
-    )
-    await submit_tx("OfferCancel", txn, client, acct.wallet)
+    txn, wallet = built
+    await submit_tx("OfferCancel", txn, client, wallet)
 
 
 async def _offer_cancel_faulty(
     accounts: dict[str, UserAccount],
+    offers: list[dict],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -269,8 +296,16 @@ async def _offer_cancel_faulty(
         [
             "non_existent_sequence",
             "cancel_others_offer",
+            "fuzz",
         ]
     )
+    if mutation == "fuzz":
+        built = _offer_cancel_base(accounts, offers)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("OfferCancel", base, client, wallet)
+        return
 
     if mutation == "non_existent_sequence":
         txn = OfferCancel(

--- a/workload/src/workload/transactions/payment_channels.py
+++ b/workload/src/workload/transactions/payment_channels.py
@@ -8,8 +8,10 @@ from xrpl.models.transactions import (
     PaymentChannelCreate,
     PaymentChannelFund,
 )
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import PaymentChannel, UserAccount
 from workload.randoms import choice, randint
 from workload.submit import submit_tx
@@ -27,44 +29,50 @@ async def channel_create(
     return await _channel_create_valid(accounts, payment_channels, client)
 
 
+def _channel_create_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[PaymentChannelCreate, Wallet] | None:
+    """Valid PaymentChannelCreate (src -> distinct dst) + wallet; shared by valid and fuzz."""
+    if len(accounts) < 2:
+        return None
+    acct_list = list(accounts.values())
+    src = choice(acct_list)
+    dst = choice([a for a in acct_list if a.address != src.address])
+    txn = PaymentChannelCreate(
+        account=src.address,
+        destination=dst.address,
+        amount=params.channel_amount(),
+        settle_delay=params.channel_settle_delay(),
+        public_key=src.wallet.public_key,
+    )
+    return txn, src.wallet
+
+
 async def _channel_create_valid(
     accounts: dict[str, UserAccount],
     payment_channels: list[PaymentChannel],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if len(accounts) < 2:
+    built = _channel_create_base(accounts)
+    if built is None:
         return
-
-    acct_list = list(accounts.values())
-    src = choice(acct_list)
-    dst = choice([a for a in acct_list if a.address != src.address])
-
-    amount = params.channel_amount()
-    settle_delay = params.channel_settle_delay()
-
-    txn = PaymentChannelCreate(
-        account=src.address,
-        destination=dst.address,
-        amount=amount,
-        settle_delay=settle_delay,
-        public_key=src.wallet.public_key,
-    )
-    result = await submit_tx("PaymentChannelCreate", txn, client, src.wallet)
+    txn, wallet = built
+    result = await submit_tx("PaymentChannelCreate", txn, client, wallet)
 
     # Track only when the submit will likely apply (state updater later swaps
     # the tx_hash placeholder for the real channel_id), else dead channels leak.
     engine = result.get("engine_result", "") if result else ""
-    if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ"):
+    if engine in ("tesSUCCESS", "terQUEUED", "terPRE_SEQ") and isinstance(txn.amount, str):
         tx_json = result.get("tx_json", result)
         tx_hash = tx_json.get("hash", "")
         if tx_hash:
             payment_channels.append(
                 PaymentChannel(
                     channel_id=tx_hash,
-                    source=src.address,
-                    destination=dst.address,
-                    amount=amount,
-                    settle_delay=settle_delay,
+                    source=txn.account,
+                    destination=txn.destination,
+                    amount=txn.amount,
+                    settle_delay=txn.settle_delay,
                 )
             )
 
@@ -83,8 +91,17 @@ async def _channel_create_faulty(
             "self_destination",
             "non_existent_destination",
             "past_cancel_after",
+            "fuzz",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _channel_create_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("PaymentChannelCreate", base, client, wallet)
+        return
 
     if mutation == "zero_amount":
         txn = PaymentChannelCreate(
@@ -133,8 +150,28 @@ async def channel_fund(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _channel_fund_faulty(accounts, client)
+        return await _channel_fund_faulty(accounts, payment_channels, client)
     return await _channel_fund_valid(accounts, payment_channels, client)
+
+
+def _channel_fund_base(
+    accounts: dict[str, UserAccount],
+    payment_channels: list[PaymentChannel],
+) -> tuple[PaymentChannelFund, Wallet] | None:
+    """Valid PaymentChannelFund (source funds own channel) + wallet; shared by valid and fuzz."""
+    if not payment_channels:
+        return None
+    channel = choice(payment_channels)
+    # Only the source can fund a channel.
+    src = accounts.get(channel.source)
+    if not src:
+        return None
+    txn = PaymentChannelFund(
+        account=src.address,
+        channel=channel.channel_id,
+        amount=params.channel_fund_amount(),
+    )
+    return txn, src.wallet
 
 
 async def _channel_fund_valid(
@@ -142,27 +179,16 @@ async def _channel_fund_valid(
     payment_channels: list[PaymentChannel],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if not payment_channels:
+    built = _channel_fund_base(accounts, payment_channels)
+    if built is None:
         return
-
-    channel = choice(payment_channels)
-    # Only the source can fund a channel.
-    src = accounts.get(channel.source)
-    if not src:
-        return
-
-    add_amount = params.channel_fund_amount()
-
-    txn = PaymentChannelFund(
-        account=src.address,
-        channel=channel.channel_id,
-        amount=add_amount,
-    )
-    await submit_tx("PaymentChannelFund", txn, client, src.wallet)
+    txn, wallet = built
+    await submit_tx("PaymentChannelFund", txn, client, wallet)
 
 
 async def _channel_fund_faulty(
     accounts: dict[str, UserAccount],
+    payment_channels: list[PaymentChannel],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -174,8 +200,17 @@ async def _channel_fund_faulty(
             "fake_channel",
             "zero_amount",
             "non_owner_fund",
+            "fuzz",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _channel_fund_base(accounts, payment_channels)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("PaymentChannelFund", base, client, wallet)
+        return
 
     if mutation == "fake_channel":
         txn = PaymentChannelFund(
@@ -208,8 +243,28 @@ async def channel_claim(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _channel_claim_faulty(accounts, client)
+        return await _channel_claim_faulty(accounts, payment_channels, client)
     return await _channel_claim_valid(accounts, payment_channels, client)
+
+
+def _channel_claim_base(
+    accounts: dict[str, UserAccount],
+    payment_channels: list[PaymentChannel],
+) -> tuple[PaymentChannelClaim, Wallet] | None:
+    """Valid PaymentChannelClaim (source or destination claims) + wallet; shared by valid+fuzz."""
+    if not payment_channels:
+        return None
+    channel = choice(payment_channels)
+    # Source or destination can submit a claim.
+    claimer_addr = choice([channel.source, channel.destination])
+    claimer = accounts.get(claimer_addr)
+    if not claimer:
+        return None
+    txn = PaymentChannelClaim(
+        account=claimer.address,
+        channel=channel.channel_id,
+    )
+    return txn, claimer.wallet
 
 
 async def _channel_claim_valid(
@@ -217,25 +272,16 @@ async def _channel_claim_valid(
     payment_channels: list[PaymentChannel],
     client: AsyncJsonRpcClient,
 ) -> None:
-    if not payment_channels:
+    built = _channel_claim_base(accounts, payment_channels)
+    if built is None:
         return
-
-    channel = choice(payment_channels)
-    # Source or destination can submit a claim.
-    claimer_addr = choice([channel.source, channel.destination])
-    claimer = accounts.get(claimer_addr)
-    if not claimer:
-        return
-
-    txn = PaymentChannelClaim(
-        account=claimer.address,
-        channel=channel.channel_id,
-    )
-    await submit_tx("PaymentChannelClaim", txn, client, claimer.wallet)
+    txn, wallet = built
+    await submit_tx("PaymentChannelClaim", txn, client, wallet)
 
 
 async def _channel_claim_faulty(
     accounts: dict[str, UserAccount],
+    payment_channels: list[PaymentChannel],
     client: AsyncJsonRpcClient,
 ) -> None:
     if not accounts:
@@ -247,8 +293,17 @@ async def _channel_claim_faulty(
             "fake_channel",
             "excessive_balance",
             "wrong_claimer",
+            "fuzz",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _channel_claim_base(accounts, payment_channels)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("PaymentChannelClaim", base, client, wallet)
+        return
 
     if mutation == "fake_channel":
         txn = PaymentChannelClaim(

--- a/workload/src/workload/transactions/payments.py
+++ b/workload/src/workload/transactions/payments.py
@@ -4,13 +4,13 @@ from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models import IssuedCurrencyAmount as IOUAmount
 from xrpl.models.amounts import MPTAmount
 from xrpl.models.transactions import Payment
+from xrpl.wallet import Wallet
 
-from workload import logging, params
+from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import MPTokenIssuance, TrustLine, UserAccount
-from workload.randoms import choice, sample
+from workload.randoms import choice, randint, sample
 from workload.submit import submit_tx
-
-log = logging.getLogger(__name__)
 
 
 async def payment_random(
@@ -24,12 +24,14 @@ async def payment_random(
     return await _payment_random_valid(accounts, trust_lines, mpt_issuances, client)
 
 
-async def _payment_random_valid(
+def _payment_random_base(
     accounts: dict[str, UserAccount],
     trust_lines: list[TrustLine],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[Payment, Wallet] | None:
+    """Valid Payment (XRP/IOU/MPT) + wallet; shared by valid and fuzz."""
+    if len(accounts) < 2:
+        return None
     src_address, dst = sample(list(accounts), 2)
     src = accounts[src_address]
 
@@ -47,12 +49,21 @@ async def _payment_random_valid(
     else:
         amount = params.payment_amount()
 
-    payment_txn = Payment(
-        account=src.address,
-        amount=amount,
-        destination=dst,
-    )
-    await submit_tx("Payment", payment_txn, client, src.wallet)
+    txn = Payment(account=src.address, amount=amount, destination=dst)
+    return txn, src.wallet
+
+
+async def _payment_random_valid(
+    accounts: dict[str, UserAccount],
+    trust_lines: list[TrustLine],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _payment_random_base(accounts, trust_lines, mpt_issuances)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("Payment", txn, client, wallet)
 
 
 def _iou_amount(trust_lines: list[TrustLine]) -> IOUAmount:
@@ -79,4 +90,40 @@ async def _payment_random_faulty(
     mpt_issuances: list[MPTokenIssuance],
     client: AsyncJsonRpcClient,
 ) -> None:
-    pass  # TODO: fault injection
+    if len(accounts) < 2:
+        return
+    src_address, dst = sample(list(accounts), 2)
+    src = accounts[src_address]
+
+    mutation = choice(
+        [
+            "overdraw_xrp",
+            "underfund_new_account",
+            "fuzz",
+        ]
+    )
+    if mutation == "fuzz":
+        built = _payment_random_base(accounts, trust_lines, mpt_issuances)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("Payment", base, client, wallet)
+        return
+
+    if mutation == "overdraw_xrp":
+        # Send far more XRP than any funded account holds -> tecUNFUNDED_PAYMENT.
+        txn = Payment(
+            account=src.address,
+            amount=str(randint(10**17, 10**18)),
+            destination=dst,
+        )
+
+    else:  # underfund_new_account
+        # Pay a brand-new account less than the base reserve -> tecNO_DST_INSUF_XRP.
+        txn = Payment(
+            account=src.address,
+            amount=str(randint(1, 1_000)),
+            destination=params.fake_account(),
+        )
+
+    await submit_tx("Payment", txn, client, src.wallet)

--- a/workload/src/workload/transactions/set_regular_key.py
+++ b/workload/src/workload/transactions/set_regular_key.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import SetRegularKey
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import UserAccount
 from workload.randoms import choice
 from workload.submit import submit_tx
@@ -20,12 +22,12 @@ async def set_regular_key(
     return await _set_regular_key_valid(accounts, client)
 
 
-async def _set_regular_key_valid(
+def _set_regular_key_base(
     accounts: dict[str, UserAccount],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[SetRegularKey, Wallet] | None:
+    """Valid SetRegularKey (set a peer as regular key, or remove it) + wallet."""
     if len(accounts) < 2:
-        return
+        return None
 
     acct_list = list(accounts.values())
     src = choice(acct_list)
@@ -43,7 +45,18 @@ async def _set_regular_key_valid(
             account=src.address,
         )
 
-    await submit_tx("SetRegularKey", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _set_regular_key_valid(
+    accounts: dict[str, UserAccount],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _set_regular_key_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("SetRegularKey", txn, client, wallet)
 
 
 async def _set_regular_key_faulty(
@@ -56,10 +69,19 @@ async def _set_regular_key_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "set_key_to_self",
             "set_key_to_fake",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _set_regular_key_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("SetRegularKey", base, client, wallet)
+        return
 
     if mutation == "set_key_to_self":
         txn = SetRegularKey(

--- a/workload/src/workload/transactions/signer_list_set.py
+++ b/workload/src/workload/transactions/signer_list_set.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models.transactions import SignerListSet
 from xrpl.models.transactions.signer_list_set import SignerEntry
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import UserAccount
 from workload.randoms import choice, randint, sample
 from workload.submit import submit_tx
@@ -21,12 +23,12 @@ async def signer_list_set(
     return await _signer_list_set_valid(accounts, client)
 
 
-async def _signer_list_set_valid(
+def _signer_list_set_base(
     accounts: dict[str, UserAccount],
-    client: AsyncJsonRpcClient,
-) -> None:
+) -> tuple[SignerListSet, Wallet] | None:
+    """Valid SignerListSet (set a multisign list, or remove it) + wallet."""
     if len(accounts) < 3:
-        return
+        return None
 
     acct_list = list(accounts.values())
     src = choice(acct_list)
@@ -60,7 +62,18 @@ async def _signer_list_set_valid(
             signer_quorum=0,
         )
 
-    await submit_tx("SignerListSet", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _signer_list_set_valid(
+    accounts: dict[str, UserAccount],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _signer_list_set_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("SignerListSet", txn, client, wallet)
 
 
 async def _signer_list_set_faulty(
@@ -73,11 +86,20 @@ async def _signer_list_set_faulty(
 
     mutation = choice(
         [
+            "fuzz",
             "fake_signers",
             "single_fake_signer",
             "high_quorum_fake_signers",
         ]
     )
+
+    if mutation == "fuzz":
+        built = _signer_list_set_base(accounts)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("SignerListSet", base, client, wallet)
+        return
 
     if mutation == "fake_signers":
         count = randint(2, 8)

--- a/workload/src/workload/transactions/tickets.py
+++ b/workload/src/workload/transactions/tickets.py
@@ -27,12 +27,14 @@ from xrpl.models.transactions.nftoken_mint import NFTokenMintFlag
 from xrpl.models.transactions.offer_create import OfferCreateFlag
 from xrpl.models.transactions.signer_list_set import SignerEntry
 from xrpl.models.transactions.transaction import Memo
+from xrpl.wallet import Wallet
 
 from workload import params
 from workload.assertions import tx_submitted
+from workload.fuzz import submit_fuzzed
 from workload.models import AMM, Credential, PermissionedDomain, UserAccount
 from workload.randoms import choice
-from workload.submit import submit_tx
+from workload.submit import submit_raw, submit_tx
 from workload.transactions.permissioned_dex import _amm_iou, _domain_members
 
 # ── Ticket-eligible transaction builders ─────────────────────────────
@@ -263,23 +265,44 @@ async def ticket_create(accounts: dict[str, UserAccount], client: AsyncJsonRpcCl
     return await _ticket_create_valid(accounts, client)
 
 
+def _ticket_create_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[xrpl.models.TicketCreate, Wallet] | None:
+    """Valid TicketCreate + wallet; shared by valid and fuzz."""
+    if not accounts:
+        return None
+    account = accounts[choice(list(accounts))]
+    txn = xrpl.models.TicketCreate(account=account.address, ticket_count=params.ticket_count())
+    return txn, account.wallet
+
+
 async def _ticket_create_valid(
     accounts: dict[str, UserAccount], client: AsyncJsonRpcClient
 ) -> None:
-    account_id = choice(list(accounts))
-    account = accounts[account_id]
-    ticket_count = params.ticket_count()
-    txn = xrpl.models.TicketCreate(
-        account=account.address,
-        ticket_count=ticket_count,
-    )
-    await submit_tx("TicketCreate", txn, client, account.wallet)
+    built = _ticket_create_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("TicketCreate", txn, client, wallet)
 
 
 async def _ticket_create_faulty(
     accounts: dict[str, UserAccount], client: AsyncJsonRpcClient
 ) -> None:
-    pass  # TODO: fault injection
+    built = _ticket_create_base(accounts)
+    if built is None:
+        return
+    base, wallet = built
+
+    if choice(["zero_count", "fuzz"]) == "fuzz":
+        await submit_fuzzed("TicketCreate", base, client, wallet)
+        return
+
+    # zero_count: TicketCount 0 -> temINVALID_COUNT (xrpl-py forbids it at construction).
+    def _mutate(d: dict) -> None:
+        d["TicketCount"] = 0
+
+    await submit_raw("TicketCreate", base, client, wallet, _mutate)
 
 
 # ── Use ──────────────────────────────────────────────────────────────
@@ -293,7 +316,7 @@ async def ticket_use(
     client: AsyncJsonRpcClient,
 ) -> None:
     if params.should_send_faulty():
-        return await _ticket_use_faulty(accounts, client)
+        return await _ticket_use_faulty(accounts, domains, credentials, amms, client)
     return await _ticket_use_valid(accounts, domains, credentials, amms, client)
 
 
@@ -336,5 +359,45 @@ async def _ticket_use_valid(
     await submit_tx(tx_type, txn, client, src.wallet)
 
 
-async def _ticket_use_faulty(accounts: dict[str, UserAccount], client: AsyncJsonRpcClient) -> None:
-    pass  # TODO: fault injection
+async def _ticket_use_faulty(
+    accounts: dict[str, UserAccount],
+    domains: list[PermissionedDomain],
+    credentials: list[Credential],
+    amms: list[AMM],
+    client: AsyncJsonRpcClient,
+) -> None:
+    accounts_with_tickets = [(addr, acc) for addr, acc in accounts.items() if acc.tickets]
+    if not accounts_with_tickets:
+        return
+    src_addr, src = choice(accounts_with_tickets)
+    ticket_sequence = choice(list(src.tickets))
+    other_accounts = [a for a in accounts if a != src_addr]
+    if not other_accounts:
+        return
+    dst = choice(other_accounts)
+    common = {"account": src.address, "sequence": 0, "ticket_sequence": ticket_sequence}
+
+    # Consumed on a tec apply; optimistic discard mirrors the valid path.
+    src.tickets.discard(ticket_sequence)
+
+    if choice(["overdraw", "fuzz"]) == "fuzz":
+        ctx = TicketCtx(
+            src=src,
+            dst=dst,
+            common=common,
+            accounts=accounts,
+            domains=domains,
+            credentials=credentials,
+            amms=amms,
+        )
+        base = _TICKET_BUILDERS[choice(list(_TICKET_BUILDERS))](ctx)
+        if base is None:
+            return
+        await submit_fuzzed("TicketUse", base, client, src.wallet)
+        return
+
+    # overdraw: a ticketed Payment that overdraws -> tecUNFUNDED_PAYMENT. It validates with
+    # TicketSequence set, so ws_listener attributes the failure to the TicketUse bucket.
+    txn = Payment(destination=dst, amount="10000000000000", **common)
+    tx_submitted("TicketUse", txn)
+    await submit_tx("Payment", txn, client, src.wallet)

--- a/workload/src/workload/transactions/trustlines.py
+++ b/workload/src/workload/transactions/trustlines.py
@@ -3,13 +3,13 @@
 from xrpl.asyncio.clients import AsyncJsonRpcClient
 from xrpl.models import IssuedCurrencyAmount as IOUAmount
 from xrpl.models.transactions import TrustSet
+from xrpl.wallet import Wallet
 
-from workload import logging, params
+from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import TrustLine, UserAccount
-from workload.randoms import sample
-from workload.submit import submit_tx
-
-log = logging.getLogger(__name__)
+from workload.randoms import choice, sample
+from workload.submit import submit_raw, submit_tx
 
 
 async def trustline_create(
@@ -20,24 +20,49 @@ async def trustline_create(
     return await _trustline_create_valid(accounts, trust_lines, client)
 
 
-async def _trustline_create_valid(
-    accounts: dict[str, UserAccount], trust_lines: list[TrustLine], client: AsyncJsonRpcClient
-) -> None:
+def _trustline_create_base(
+    accounts: dict[str, UserAccount],
+) -> tuple[TrustSet, Wallet] | None:
+    """Valid TrustSet (account trusts another as IOU issuer) + wallet; shared by valid and fuzz."""
+    if len(accounts) < 2:
+        return None
     account_id, other_id = sample(list(accounts), 2)
     account = accounts[account_id]
-    currency = params.currency_code()
     txn = TrustSet(
         account=account.address,
         limit_amount=IOUAmount(
-            currency=currency,
+            currency=params.currency_code(),
             issuer=other_id,
             value=params.trustline_limit(),
         ),
     )
-    await submit_tx("TrustSet", txn, client, account.wallet)
+    return txn, account.wallet
+
+
+async def _trustline_create_valid(
+    accounts: dict[str, UserAccount], trust_lines: list[TrustLine], client: AsyncJsonRpcClient
+) -> None:
+    built = _trustline_create_base(accounts)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("TrustSet", txn, client, wallet)
 
 
 async def _trustline_create_faulty(
     accounts: dict[str, UserAccount], trust_lines: list[TrustLine], client: AsyncJsonRpcClient
 ) -> None:
-    pass  # TODO: fault injection
+    built = _trustline_create_base(accounts)
+    if built is None:
+        return
+    base, wallet = built
+
+    if choice(["self_trust", "fuzz"]) == "fuzz":
+        await submit_fuzzed("TrustSet", base, client, wallet)
+        return
+
+    # self_trust: issuer == account -> temDST_IS_SRC (xrpl-py forbids it at construction).
+    def _mutate(d: dict) -> None:
+        d["LimitAmount"]["issuer"] = d["Account"]
+
+    await submit_raw("TrustSet", base, client, wallet, _mutate)

--- a/workload/src/workload/transactions/vaults.py
+++ b/workload/src/workload/transactions/vaults.py
@@ -14,8 +14,10 @@ from xrpl.models.transactions import (
     VaultSet,
     VaultWithdraw,
 )
+from xrpl.wallet import Wallet
 
 from workload import params
+from workload.fuzz import submit_fuzzed
 from workload.models import MPTokenIssuance, TrustLine, UserAccount, Vault
 from workload.randoms import choice, randint, random
 from workload.submit import submit_tx
@@ -70,15 +72,14 @@ async def vault_create(
     return await _vault_create_valid(accounts, vaults, trust_lines, mpt_issuances, client)
 
 
-async def _vault_create_valid(
+def _vault_create_base(
     accounts: dict[str, UserAccount],
-    vaults: list[Vault],
     trust_lines: list[TrustLine],
     mpt_issuances: list[MPTokenIssuance],
-    client: AsyncJsonRpcClient,
-) -> None:
-    src_address = choice(list(accounts))
-    src = accounts[src_address]
+) -> tuple[VaultCreate, Wallet] | None:
+    if not accounts:
+        return None
+    src = accounts[choice(list(accounts))]
     asset = _random_asset(trust_lines, mpt_issuances)
     txn = VaultCreate(
         account=src.address,
@@ -86,7 +87,21 @@ async def _vault_create_valid(
         assets_maximum=params.vault_assets_maximum(),
         data=params.vault_data(),
     )
-    await submit_tx("VaultCreate", txn, client, src.wallet)
+    return txn, src.wallet
+
+
+async def _vault_create_valid(
+    accounts: dict[str, UserAccount],
+    vaults: list[Vault],
+    trust_lines: list[TrustLine],
+    mpt_issuances: list[MPTokenIssuance],
+    client: AsyncJsonRpcClient,
+) -> None:
+    built = _vault_create_base(accounts, trust_lines, mpt_issuances)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("VaultCreate", txn, client, wallet)
 
 
 async def _vault_create_faulty(
@@ -100,7 +115,14 @@ async def _vault_create_faulty(
         return
     src = choice(list(accounts.values()))
     asset = _random_asset(trust_lines, mpt_issuances)
-    mutation = choice(["zero_max", "oversized_data", "xrp_with_issuer"])
+    mutation = choice(["fuzz", "zero_max", "oversized_data", "xrp_with_issuer"])
+    if mutation == "fuzz":
+        built = _vault_create_base(accounts, trust_lines, mpt_issuances)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("VaultCreate", base, client, wallet)
+        return
     if mutation == "zero_max":
         txn = VaultCreate(
             account=src.address,
@@ -141,20 +163,29 @@ async def vault_deposit(
     return await _vault_deposit_valid(accounts, vaults, client)
 
 
-async def _vault_deposit_valid(
-    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
-) -> None:
-    if not vaults:
-        return
+def _vault_deposit_base(
+    accounts: dict[str, UserAccount], vaults: list[Vault]
+) -> tuple[VaultDeposit, Wallet] | None:
+    if not vaults or not accounts:
+        return None
     vault = choice(vaults)
-    depositor_id = choice(list(accounts))
-    depositor = accounts[depositor_id]
+    depositor = accounts[choice(list(accounts))]
     txn = VaultDeposit(
         account=depositor.address,
         vault_id=vault.vault_id,
         amount=_amount_for_asset(vault.asset),
     )
-    await submit_tx("VaultDeposit", txn, client, depositor.wallet)
+    return txn, depositor.wallet
+
+
+async def _vault_deposit_valid(
+    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
+) -> None:
+    built = _vault_deposit_base(accounts, vaults)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("VaultDeposit", txn, client, wallet)
 
 
 async def _vault_deposit_faulty(
@@ -163,7 +194,14 @@ async def _vault_deposit_faulty(
     if not accounts:
         return
     depositor = choice(list(accounts.values()))
-    mutation = choice(["fake_vault", "zero_amount", "mismatched_asset"])
+    mutation = choice(["fuzz", "fake_vault", "zero_amount", "mismatched_asset"])
+    if mutation == "fuzz":
+        built = _vault_deposit_base(accounts, vaults)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("VaultDeposit", base, client, wallet)
+        return
     if mutation == "fake_vault":
         if not vaults:
             return
@@ -222,21 +260,31 @@ def _state_aware_withdraw_amount(vault: Vault) -> IOUAmount | MPTAmount | str:
     return str(amount)
 
 
-async def _vault_withdraw_valid(
-    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
-) -> None:
+def _vault_withdraw_base(
+    accounts: dict[str, UserAccount], vaults: list[Vault]
+) -> tuple[VaultWithdraw, Wallet] | None:
     if not vaults:
-        return
+        return None
     vault = choice(vaults)
     if vault.owner not in accounts:
-        return
+        return None
     owner = accounts[vault.owner]
     txn = VaultWithdraw(
         account=owner.address,
         vault_id=vault.vault_id,
         amount=_state_aware_withdraw_amount(vault),
     )
-    await submit_tx("VaultWithdraw", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _vault_withdraw_valid(
+    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
+) -> None:
+    built = _vault_withdraw_base(accounts, vaults)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("VaultWithdraw", txn, client, wallet)
 
 
 async def _vault_withdraw_faulty(
@@ -245,7 +293,14 @@ async def _vault_withdraw_faulty(
     if not accounts or not vaults:
         return
     vault = choice(vaults)
-    mutation = choice(["fake_vault", "non_owner", "overdraw"])
+    mutation = choice(["fuzz", "fake_vault", "non_owner", "overdraw"])
+    if mutation == "fuzz":
+        built = _vault_withdraw_base(accounts, vaults)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("VaultWithdraw", base, client, wallet)
+        return
     if mutation == "overdraw":
         if vault.owner not in accounts:
             return
@@ -295,14 +350,14 @@ async def vault_set(
     return await _vault_set_valid(accounts, vaults, client)
 
 
-async def _vault_set_valid(
-    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
-) -> None:
+def _vault_set_base(
+    accounts: dict[str, UserAccount], vaults: list[Vault]
+) -> tuple[VaultSet, Wallet] | None:
     if not vaults:
-        return
+        return None
     vault = choice(vaults)
     if vault.owner not in accounts:
-        return
+        return None
     owner = accounts[vault.owner]
     txn = VaultSet(
         account=owner.address,
@@ -310,7 +365,17 @@ async def _vault_set_valid(
         assets_maximum=params.vault_assets_maximum(),
         data=params.vault_data(),
     )
-    await submit_tx("VaultSet", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _vault_set_valid(
+    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
+) -> None:
+    built = _vault_set_base(accounts, vaults)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("VaultSet", txn, client, wallet)
 
 
 async def _vault_set_faulty(
@@ -319,7 +384,14 @@ async def _vault_set_faulty(
     if not accounts or not vaults:
         return
     vault = choice(vaults)
-    mutation = choice(["fake_vault", "non_owner"])
+    mutation = choice(["fuzz", "fake_vault", "non_owner"])
+    if mutation == "fuzz":
+        built = _vault_set_base(accounts, vaults)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("VaultSet", base, client, wallet)
+        return
     if mutation == "fake_vault":
         if vault.owner not in accounts:
             return
@@ -356,22 +428,32 @@ async def vault_delete(
     return await _vault_delete_valid(accounts, vaults, client)
 
 
-async def _vault_delete_valid(
-    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
-) -> None:
+def _vault_delete_base(
+    accounts: dict[str, UserAccount], vaults: list[Vault]
+) -> tuple[VaultDelete, Wallet] | None:
     if not vaults:
-        return
+        return None
     # Non-empty vaults return tecNO_PERMISSION
     empty = [v for v in vaults if v.balance <= 0 and v.owner in accounts]
     vault = choice(empty) if empty else choice(vaults)
     if vault.owner not in accounts:
-        return
+        return None
     owner = accounts[vault.owner]
     txn = VaultDelete(
         account=owner.address,
         vault_id=vault.vault_id,
     )
-    await submit_tx("VaultDelete", txn, client, owner.wallet)
+    return txn, owner.wallet
+
+
+async def _vault_delete_valid(
+    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
+) -> None:
+    built = _vault_delete_base(accounts, vaults)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("VaultDelete", txn, client, wallet)
 
 
 async def _vault_delete_faulty(
@@ -380,7 +462,14 @@ async def _vault_delete_faulty(
     if not accounts or not vaults:
         return
     vault = choice(vaults)
-    mutation = choice(["fake_vault", "non_owner"])
+    mutation = choice(["fuzz", "fake_vault", "non_owner"])
+    if mutation == "fuzz":
+        built = _vault_delete_base(accounts, vaults)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("VaultDelete", base, client, wallet)
+        return
     if mutation == "fake_vault":
         if vault.owner not in accounts:
             return
@@ -424,23 +513,23 @@ def _get_asset_issuer(vault: Vault) -> str | None:
     return None
 
 
-async def _vault_clawback_valid(
-    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
-) -> None:
+def _vault_clawback_base(
+    accounts: dict[str, UserAccount], vaults: list[Vault]
+) -> tuple[VaultClawback, Wallet] | None:
     if not vaults:
-        return
+        return None
     # VaultClawback must be submitted by the asset issuer, not the vault owner.
     eligible = [v for v in vaults if _get_asset_issuer(v) in accounts and v.shareholders]
     if not eligible:
-        return
+        return None
     vault = choice(eligible)
     issuer_address = _get_asset_issuer(vault)
     if issuer_address is None:
-        return
+        return None
     issuer = accounts[issuer_address]
     amount = _clawback_amount(vault.asset)
     if amount is None:
-        return
+        return None
     holder = choice(list(vault.shareholders))
     txn = VaultClawback(
         account=issuer.address,
@@ -448,7 +537,17 @@ async def _vault_clawback_valid(
         holder=holder,
         amount=amount,
     )
-    await submit_tx("VaultClawback", txn, client, issuer.wallet)
+    return txn, issuer.wallet
+
+
+async def _vault_clawback_valid(
+    accounts: dict[str, UserAccount], vaults: list[Vault], client: AsyncJsonRpcClient
+) -> None:
+    built = _vault_clawback_base(accounts, vaults)
+    if built is None:
+        return
+    txn, wallet = built
+    await submit_tx("VaultClawback", txn, client, wallet)
 
 
 async def _vault_clawback_faulty(
@@ -463,7 +562,14 @@ async def _vault_clawback_faulty(
     amount = _clawback_amount(vault.asset)
     if amount is None:
         return
-    mutation = choice(["fake_vault", "clawback_self"])
+    mutation = choice(["fuzz", "fake_vault", "clawback_self"])
+    if mutation == "fuzz":
+        built = _vault_clawback_base(accounts, vaults)
+        if built is None:
+            return
+        base, wallet = built
+        await submit_fuzzed("VaultClawback", base, client, wallet)
+        return
     if mutation == "fake_vault":
         other_accounts = [a for a in accounts if a != vault.owner]
         if not other_accounts:


### PR DESCRIPTION
Extends generative fuzzing (`fuzz.py::submit_fuzzed`) from the 7 pilot handlers to **every** registered transaction type, so the whole workload exercises rippled's transactor logic with hostile-but-encodable inputs, not just curated vectors.

## What changed
- Every `_faulty` handler now offers a `"fuzz"` choice alongside its curated mutations, sharing a `_<name>_base()` builder with the valid path (extracted where it didn't exist).
- The 14 `pass # TODO: fault injection` stubs are now real faulty paths (base + fuzz + ≥1 curated tec vector).
- `MPTokenIssuanceCreate` (previously valid-only) gains a `should_send_faulty()` dispatch and faulty path.
- Engine-result codes for new curated vectors were checked against the rippled transactors.

## Exclusions / gotchas
- **LoanSet** is the sole handler excluded from fuzz: it dual co-signs (broker), and `submit_fuzzed` rides single-wallet `submit_raw`, so a fuzzed LoanSet would only hit shallow auth rejects. Its curated vectors stay.
- **Batch** is single-account, so the outer dict is fuzzed directly (only multi-account batches need `BatchSigners`).
- `assertions._NO_FAILURE_TYPES` gains `AccountSet`, `SetRegularKey`, `TrustSet`, `TicketCreate`, `NFTokenCancelOffer` — their faulty paths can't reach a `tec` (tem-only malformations or tesSUCCESS no-ops), so `sometimes(failure)` would starve. Comment updated for `MPTokenIssuanceCreate`.
- New `scripts/check-fuzz-coverage` (wired into CI) fails for any `_faulty` lacking a `submit_fuzzed` branch, with an explicit exclusion set (`LoanSet`).

## Verification
- `check-imports`, `check-endpoints`, `check-fuzz-coverage`, `ruff check`, `ruff format --check`, `mypy`, `basedpyright` — all green.
- Live-node smoke (`/local-run`) not run: no `xrpld` binary in the build environment. The new handlers replicate the runtime-proven pilot pattern; recommend a node/Antithesis run before merge to confirm fuzz events and assertion buckets.